### PR TITLE
Add no-param-reassign config

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,8 +101,16 @@ module.exports = {
         }],
 
         /**
-         * Prefer the '+=' operator. Allow unary operators in for loops, because it is a common
-         * pattern.
+            This rule disallows assigning to function parameters; function parameters are
+            treated as const bindings. Some more readable or type-safe alternatives:
+            - use default parameters
+            - assign to a new variable with a stricter type and descriptive name
+         */
+        'no-param-reassign': ['error', { props: false }],
+
+        /**
+            Prefer the '+=' operator. Allow unary operators in for loops, because it is a common
+            pattern.
          */
         'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
 
@@ -128,11 +136,11 @@ module.exports = {
             }],
 
         /**
-         * Underscore prefixes are permitted only to indicate fields that are for private internal
-         * use. Trailing or prefixed underscores that signify other use cases are not allowed.
-         * Different guidelines may exist for languages that support private fields, such as
-         * TypeScript. The JavaScript guidelines are subject to change if availability of private
-         * fields changes in the JavaScript ecosystem.
+            Underscore prefixes are permitted only to indicate fields that are for private internal
+            use. Trailing or prefixed underscores that signify other use cases are not allowed.
+            Different guidelines may exist for languages that support private fields, such as
+            TypeScript. The JavaScript guidelines are subject to change if availability of private
+            fields changes in the JavaScript ecosystem.
          */
         'no-underscore-dangle': 'off',
 

--- a/index.js
+++ b/index.js
@@ -102,7 +102,8 @@ module.exports = {
 
         /**
             This rule disallows assigning to function parameters; function parameters are
-            treated as const bindings. Some more readable or type-safe alternatives:
+            treated as const bindings. Some more readable or type-safe alternatives to
+            parameter assignment are:
             - use default parameters
             - assign to a new variable with a stricter type and descriptive name
          */


### PR DESCRIPTION
Updates the `no-param-reassign` configuration to treat function parameters as `const` bindings.

Testing locally, I was not able to just set `'no-param-reassign': 'error'` as it appears that the exisiting eslint config which sets `'no-param-reassign': ['error', {props: true, ...}]` was overriding the default configuration.

To allow assignment to properties of parameters (ie `const` behavior) I explicitly set `props: false`.