### PR TITLE
Do not require tsx extension in imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ module.exports = {
             js: 'never',
             mjs: 'never',
             jsx: 'never',
-            ts: 'never'
+            ts: 'never',
+            tsx: 'never'
         }],
 
         /*


### PR DESCRIPTION
If we do not require jsx and ts extensions, we should also not require tsx extensions.