### PR TITLE
Inlcude typescript.js in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "access": "public"
   },
   "files": [
-    ".eslintrc.js"
+    ".eslintrc.js",
+    "typescript.js"
   ],
   "dependencies": {
     "@typescript-eslint/parser": "^4.9.1",


### PR DESCRIPTION
The TypeScript configuration must be listed in the files array in order to be included in the published npm package.