### PR TITLE
Add recommended TypeScript rules part 1

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -1,5 +1,5 @@
 module.exports = {
-    extends: './index',
+    extends: ['./index', 'plugin:@typescript-eslint/recommended'],
     parser: '@typescript-eslint/parser',
     rules: {
         /*
@@ -64,26 +64,5 @@ module.exports = {
         }],
         'space-infix-ops': 'off',
         '@typescript-eslint/space-infix-ops': 'error',
-        /*
-            The following are TypeScript specific rules that do not require type
-            checking to run.
-        */
-        '@typescript-eslint/adjacent-overload-signatures': 'error',
-        '@typescript-eslint/ban-ts-comment': 'error',
-        '@typescript-eslint/ban-types': 'error',
-        '@typescript-eslint/explicit-module-boundary-types': 'warn',
-        '@typescript-eslint/no-empty-interface': 'error',
-        '@typescript-eslint/no-explicit-any': 'warn',
-        '@typescript-eslint/no-extra-non-null-assertion': 'error',
-        '@typescript-eslint/no-inferrable-types': 'error',
-        '@typescript-eslint/no-misused-new': 'error',
-        '@typescript-eslint/no-namespace': 'error',
-        '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
-        '@typescript-eslint/no-non-null-assertion': 'warn',
-        '@typescript-eslint/no-this-alias': 'error',
-        '@typescript-eslint/no-var-requires': 'error',
-        '@typescript-eslint/prefer-as-const': 'error',
-        '@typescript-eslint/prefer-namespace-keyword': 'error',
-        '@typescript-eslint/triple-slash-reference': 'error',
     }
 };

--- a/typescript.js
+++ b/typescript.js
@@ -63,6 +63,27 @@ module.exports = {
             asyncArrow: 'always'
         }],
         'space-infix-ops': 'off',
-        '@typescript-eslint/space-infix-ops': 'error'
+        '@typescript-eslint/space-infix-ops': 'error',
+        /*
+            The following are TypeScript specific rules that do not require type
+            checking to run.
+        */
+        '@typescript-eslint/adjacent-overload-signatures': 'error',
+        '@typescript-eslint/ban-ts-comment': 'error',
+        '@typescript-eslint/ban-types': 'error',
+        '@typescript-eslint/explicit-module-boundary-types': 'warn',
+        '@typescript-eslint/no-empty-interface': 'error',
+        '@typescript-eslint/no-explicit-any': 'warn',
+        '@typescript-eslint/no-extra-non-null-assertion': 'error',
+        '@typescript-eslint/no-inferrable-types': 'error',
+        '@typescript-eslint/no-misused-new': 'error',
+        '@typescript-eslint/no-namespace': 'error',
+        '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
+        '@typescript-eslint/no-non-null-assertion': 'warn',
+        '@typescript-eslint/no-this-alias': 'error',
+        '@typescript-eslint/no-var-requires': 'error',
+        '@typescript-eslint/prefer-as-const': 'error',
+        '@typescript-eslint/prefer-namespace-keyword': 'error',
+        '@typescript-eslint/triple-slash-reference': 'error',
     }
 };


### PR DESCRIPTION
This PR adds the set of recommended rules from the typescript-eslint package that do NOT require type checking. Pulled from here: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/configs/recommended.ts

I removed the rules that conflicted with the ones we already had in the file. 
You can find the table of all rules here to understand their usage:
https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules