### PR TITLE
Use  @typescript-eslint/all for now to help evaluate all lint rules

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -1,5 +1,5 @@
 module.exports = {
-    extends: ['./index', 'plugin:@typescript-eslint/recommended'],
+    extends: ['./index', 'plugin:@typescript-eslint/all'],
     parser: '@typescript-eslint/parser',
     rules: {
         /*


### PR DESCRIPTION
This PR changes "@typescript-eslint/recommended" to "@typescript-eslint/all" so that we can start with a very strict ruleset and whittle down to the rules we actually want.

### Testing: 
I tested that I could use this change in an existing typescript codebase and see errors for rules that aren't included in the recommended set (e.g. @typescript-eslint/explicit-function-return-type )