### PR TITLE
Enable TypeScript Rules Requiring Type Checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Extend `@ni/eslint-config/typescript-requiring-type-checking` in a separate ESLi
 
 ```json
 {
-    "extends": ["@ni/eslint-config/typescript-requiring-type-checking"],
+    "extends": "@ni/eslint-config/typescript-requiring-type-checking",
     "parserOptions": {
         "project": "tsconfig.json"
     }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Welcome to NI's JavaScript and TypeScript linter rules for [ESLint](https://esli
 
 ## Installation
 
-Install @ni/eslint-config and its peer dependencies.
+Install `@ni/eslint-config` and its peer dependencies.
 
 Use [npm view](https://docs.npmjs.com/cli/view.html) to list the correct versions of each package to install yourself.
 
@@ -24,7 +24,7 @@ npx install-peerdeps --dev @ni/eslint-config
 
 ### JavaScript
 
-Extend @ni in the ESLint configuration.
+Extend `@ni` in the default ESLint configuration, ie `.eslintrc.json`.
 
 ```json
 {
@@ -34,12 +34,21 @@ Extend @ni in the ESLint configuration.
 
 ### TypeScript
 
-Extend @ni/eslint-config/typescript in the ESLint configuration. Configure the @typescript-eslint plugin and the project's TypeScript configuration.
+Extend `@ni/eslint-config/typescript` in the default ESLint configuration. The default `.eslintrc.json` used for development should only extend TypeScript rules and not the TypeScript rules requiring type checking.
 
 ```json
 {
     "extends": "@ni/eslint-config/typescript",
-    "plugins": ["@typescript-eslint"],
+}
+```
+
+### TypeScript Rules Requiring Type Checking
+
+Extend `@ni/eslint-config/typescript-requiring-type-checking` in a separate ESLint configuration. Configure the project's TypeScript configuration. Due to the longer execution time, the separate `.eslintrc-requires-type-checking.json` should only run from an explicit `npm run lint` command invoked by developers and on CIs.
+
+```json
+{
+    "extends": ["@ni/eslint-config/typescript-requiring-type-checking"],
     "parserOptions": {
         "project": "tsconfig.json"
     }

--- a/lib/typescript-extensions-requiring-type-checking.js
+++ b/lib/typescript-extensions-requiring-type-checking.js
@@ -1,23 +1,23 @@
 module.exports = {
     rules: {
         // Defined by Airbnb
-        // 'dot-notation': 'off',
-        // '@typescript-eslint/dot-notation': ['error', { allowKeywords: true }],
+        'dot-notation': 'off',
+        '@typescript-eslint/dot-notation': ['error', { allowKeywords: true }],
 
         // Defined by Airbnb
-        // 'no-implied-eval': 'off',
-        // '@typescript-eslint/no-implied-eval': 'error',
+        'no-implied-eval': 'off',
+        '@typescript-eslint/no-implied-eval': 'error',
 
         // Defined by Airbnb
-        // 'no-throw-literal': 'off',
-        // '@typescript-eslint/no-throw-literal': 'error',
+        'no-throw-literal': 'off',
+        '@typescript-eslint/no-throw-literal': 'error',
 
         // Defined by Airbnb
-        // 'require-await': 'off',
-        // '@typescript-eslint/require-await': 'off',
+        'require-await': 'off',
+        '@typescript-eslint/require-await': 'off',
 
         // Defined by Airbnb
-        // 'no-return-await': 'off',
-        // '@typescript-eslint/return-await': 'error',
+        'no-return-await': 'off',
+        '@typescript-eslint/return-await': 'error',
     }
 };

--- a/typescript-requiring-type-checking.js
+++ b/typescript-requiring-type-checking.js
@@ -15,23 +15,23 @@ module.exports = {
         /*
             TypeScript rules outside of the recommended configuration
         */
-        // '@typescript-eslint/naming-convention': 'error',
-        // '@typescript-eslint/no-base-to-string': 'error',
-        // '@typescript-eslint/no-confusing-void-expression': 'error',
-        // '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
-        // '@typescript-eslint/no-unnecessary-condition': 'error',
-        // '@typescript-eslint/no-unnecessary-qualifier': 'error',
-        // '@typescript-eslint/no-unnecessary-type-arguments': 'error',
-        // '@typescript-eslint/non-nullable-type-assertion-style': 'error',
-        // '@typescript-eslint/prefer-includes': 'error',
-        // '@typescript-eslint/prefer-nullish-coalescing': 'error',
-        // '@typescript-eslint/prefer-readonly': 'error',
-        // '@typescript-eslint/prefer-readonly-parameter-types': 'error',
-        // '@typescript-eslint/prefer-reduce-type-parameter': 'error',
-        // '@typescript-eslint/prefer-string-starts-ends-with': 'error',
-        // '@typescript-eslint/promise-function-async': 'error',
-        // '@typescript-eslint/require-array-sort-compare': 'error',
-        // '@typescript-eslint/strict-boolean-expressions': 'error',
-        // '@typescript-eslint/switch-exhaustiveness-check': 'error'
+        '@typescript-eslint/naming-convention': 'error',
+        '@typescript-eslint/no-base-to-string': 'error',
+        '@typescript-eslint/no-confusing-void-expression': 'error',
+        '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
+        '@typescript-eslint/no-unnecessary-condition': 'error',
+        '@typescript-eslint/no-unnecessary-qualifier': 'error',
+        '@typescript-eslint/no-unnecessary-type-arguments': 'error',
+        '@typescript-eslint/non-nullable-type-assertion-style': 'error',
+        '@typescript-eslint/prefer-includes': 'error',
+        '@typescript-eslint/prefer-nullish-coalescing': 'error',
+        '@typescript-eslint/prefer-readonly': 'error',
+        '@typescript-eslint/prefer-readonly-parameter-types': 'error',
+        '@typescript-eslint/prefer-reduce-type-parameter': 'error',
+        '@typescript-eslint/prefer-string-starts-ends-with': 'error',
+        '@typescript-eslint/promise-function-async': 'error',
+        '@typescript-eslint/require-array-sort-compare': 'error',
+        '@typescript-eslint/strict-boolean-expressions': 'error',
+        '@typescript-eslint/switch-exhaustiveness-check': 'error'
     }
 };


### PR DESCRIPTION
The goal of this PR is to evaluate rules used in `typescript-requiring-type-checking.js`.

To test locally, you can add the dependencies to a project with the instructions in the current published [README](https://github.com/ni/javascript-styleguide#installation) as it uses the latest dependency versions.

**Note:** The dependency versions have changed since the last PR so make sure you are up to date.

Download the zip for the build artifact (see below) and extract the contents (ie the single tgz file). **Note:** you do not need to extract the tgz file itself. With the tgz file on disk run the following command:

`npm install -D <path_to_tgz_file>`

This PR also makes the following changes to review:
- Updates to the README.md

Build Artifacts:
- [Initial PR](https://github.com/ni/javascript-styleguide/actions/runs/654563358)

**NOTE: due to a mistake of deleting the source branch of this PR this PR will not be merged and instead the following branch will be in a follow-up PR: https://github.com/rajsite/javascript-styleguide/tree/enable-requires-typechecking-complete**