### PR TITLE
Add a link to the documentation on ESlint configurations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npx install-peerdeps --dev @ni/eslint-config
 
 ### JavaScript
 
-Extend @ni in the ESLint configuration.
+Extend @ni in the [ESLint configuration](https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats).
 
 ```json
 {


### PR DESCRIPTION
- Add a link to the documentation on ESlint configurations.

Notes:
- I found it convenient to link the configuration documentation while installing and setting up ESLint.

Tested