### PR TITLE
Disable the prefer-destructuring rule.

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,6 +213,12 @@ module.exports = {
         'object-shorthand': ['error', 'properties', { avoidQuotes: true }],
 
         /*
+            Destructuring should be considered for multi-variable declarations and assignments while simple single
+            variable declarations and assignments likely don't require it.
+        */
+        'prefer-destructuring': 'off',
+
+        /*
             This configuration already supports the JSDoc syntax. Add additional syntax as line or
             block exceptions or markers when necessary.
         */


### PR DESCRIPTION
- Disable the [prefer-destructuring](https://eslint.org/docs/rules/prefer-destructuring) rule.

Notes
- I tested this rule following previous concern about its necessity and found 73 errors in one codebase most of which were a complete waste of the developers' time. There are many single variable use cases where destructuring is actually not preferred.
- Examples:
```typescript
const ruleId = this.route.snapshot.queryParams.ruleId;
// Even in this multi-variable case, destructuring doesn't pose enough of an advantage.
this._startDate = this.range[0];
this._endDate = this.range[1];
// Are you kidding me?
const trigger = this.trigger;
// Must be rocket science.
const featureId = DataAlarmRuleHelper.getFeatureConfig(this.rule).featureId;
```

Tested
- Verified that the errors are removed