### PR TITLE
Disable the no-continue rule.

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,8 @@ module.exports = {
         'no-console': 'error',
 
         /*
-            Continue statements are a common, useful, and can improve readability. Use of labels is disallowed.
+            `continue` statements can improve readability but care should be taken to avoid confusing control flow.
+            They should generally be the only statement within an `if` block and should never use labels.
         */
         'no-continue': 'off',
 

--- a/index.js
+++ b/index.js
@@ -97,6 +97,11 @@ module.exports = {
         'no-console': 'error',
 
         /*
+            Continue statements are a common, useful, and can improve readability. Use of labels is disallowed.
+        */
+        'no-continue': 'off',
+
+        /*
             There may be exceptions, like array iterators, where it is appropriate to disable this
             rule with an inline comment.
         */


### PR DESCRIPTION
- Disable the [no-continue](https://eslint.org/docs/rules/no-continue) rule.

Notes
- This rule produced 39 errors.
- It doesn't look like we addressed this rule in the [airbnb review](https://ni.visualstudio.com/Users/_git/abarreto-misc/pullrequest/83582?_a=files&path=%2Fairbnb-js-review%2Frules%2Fstyle.js) line 279.
- Continue statements are a common programming construct, and our developers are capable of using it properly.
- The examples in the rule's documentation are questionable.

Tested
- Verified that the errors are removed