### PR TITLE
 Elevate recommended TypeScript rules from warning to error

### DIFF
--- a/tools/print-typescript-properties.js
+++ b/tools/print-typescript-properties.js
@@ -28,6 +28,21 @@ const typeScriptRequiringTypeChecks = Object.keys(plugin.rules)
     .filter(key => !recommended(key))
     .filter(key => requiresTypeChecking(key));
 
+const typeScriptRecommended = Object.keys(plugin.rules)
+    .filter(key => !extendsBaseRule(key))
+    .filter(key => recommended(key))
+    .filter(key => !requiresTypeChecking(key));
+
+const typeScriptRecommendedTypeChecks = Object.keys(plugin.rules)
+    .filter(key => !extendsBaseRule(key))
+    .filter(key => recommended(key))
+    .filter(key => requiresTypeChecking(key));
+
+global.console.log('Note: When printing this does not print the default config and assumes "error"');
+global.console.log('TypeScript Recommended:');
+print(typeScriptRecommended);
+global.console.log('TypeScript Recommended Requiring Type Checks:');
+print(typeScriptRecommendedTypeChecks);
 global.console.log('TypeScript Extensions:');
 print(typeScriptExtensions);
 global.console.log('TypeScript Extensions Requiring Type Checks:');

--- a/typescript.js
+++ b/typescript.js
@@ -19,7 +19,11 @@ module.exports = {
             https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/configs/recommended.ts
         */
 
-        // None
+        // The following elevate recommended rules from warning to error
+        '@typescript-eslint/explicit-module-boundary-types': 'error',
+        '@typescript-eslint/no-explicit-any': 'error',
+        '@typescript-eslint/no-non-null-assertion': 'error',
+        '@typescript-eslint/no-unused-vars': 'error',
 
         /*
             TypeScript rules outside of the recommended configuration


### PR DESCRIPTION
The existing recommended rules used by the typescript.js config have [several rules configured as `warn`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/configs/recommended.ts#L17) instead of as `error`.

This change updates the rules to always error. Interested if exisiting code bases testing the TypeScript ESlint rules noticed the warnings and if we have concerns with making these recommended rules stricter.

The change also updates the `print-typescript-properties.js` tool to make it easier to audit recommended rules.