### PR TITLE
Add print-evaluated-rules script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,8 @@ jobs:
     # Test
     - run: npm run test-typescript
     - run: npm run test-typescript-typed
-    - run: npm run dev-print-typescript-props
-    - run: npm run dev-has-warn
+    - run: npm run print-typescript-properties
+    - run: npm run print-evaluated-rules
 
     # Publish
     - if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
     - run: npm run test-typescript
     - run: npm run test-typescript-typed
     - run: npm run dev-print-typescript-props
+    - run: npm run dev-has-warn
 
     # Publish
     - if: startsWith(github.ref, 'refs/tags/v')

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing
 
-This document covers information needed for contribution to and release of the eslint rules.
+This document covers information needed for the contribution to and release of the eslint rules.
 
 ## Guiding Principles
 
-Some overarching principles that are used for defining the rulesets.
+Some overarching principles that are used for defining the rulesets:
 
 1. Start strict and then loosen. We prefer to start with a strict set of opinionated rules and then loosen the ruleset with experience developing under them.
 2. Use `error` or `off`; no `warn`. Allowing `warn` tends to increase noise when running lints and hide new or useful messages. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,33 @@
-# Release Workflow
+# Contributing
 
-This document covers the workflow for creating a new release of the lint rules.
+This document covers information needed for contribution to and release of the eslint rules.
 
-## Overview
+## Guiding Principles
+
+Some overarching principles that are used for defining the rulesets.
+
+1. Start strict and then loosen. We prefer to start with a strict set of opinionated rules and then loosen the ruleset with experience developing under them.
+2. Use `error` or `off`; no `warn`. Allowing `warn` tends to increase noise when running lints and hide new or useful messages. 
+
+## Development Scripts
+
+Several scripts are provided for local development to help audit changes to the ruleset.
+
+### Checking for new TypeScript rules
+
+When updating the TypeScript rule npm packages the `npm run print-typescript-properties` command can be used to print all the available rules.
+
+**Note:** This command does not print what rules are currently used but instead prints all the rules that are available.
+
+The TypeScript extension rules (which are rules that extend the behavior of exisiting eslint rules) must be used in place of corresponding eslint rules. Printing the available rules is useful for manually auditing what extension rules need to be used.
+
+### Checking the evaluated rules
+
+The rules build on several exisiting rulesets such as the airbnb ruleset, the eslint recommended ruleset, the TypeScript recommended ruleset, etc. The `npm run print-evaluated-rules` commands helps to audit the final resolved rule values.
+
+When the command is run it will print a JSON representation of each of the maintained rulesets. In addition the command will print the result of some audits that try to detect patterns we want to avoid, such as rules configured with a `warn` severity level.
+
+## Release workflow
 
 A manual versioning strategy is used based on the `npm version` command workflow.
 After one or more changes have been merged into master a project administrator will create a release using the following workflow:
@@ -33,7 +58,7 @@ Example running the release commands as a project administrator:
 > git push --follow-tags
 ```
 
-## Rules for version change
+### Rules for version change
 
 The following are guidelines for when to release as `patch`, `minor`, or `major` versions:
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test": "eslint .",
     "test-typescript": "eslint ./test/typescript/",
     "test-typescript-typed": "eslint ./test/typescript-type-checking/",
-    "dev-print-typescript-props": "node ./tools/print-typescript-properties",
-    "dev-has-warn": "node ./tools/has-warn"
+    "print-typescript-properties": "node ./tools/print-typescript-properties",
+    "print-evaluated-rules": "node ./tools/print-evaluated-rules"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "eslint .",
     "test-typescript": "eslint ./test/typescript/",
     "test-typescript-typed": "eslint ./test/typescript-type-checking/",
-    "dev-print-typescript-props": "node ./tools/print-typescript-properties"
+    "dev-print-typescript-props": "node ./tools/print-typescript-properties",
+    "dev-has-warn": "node ./tools/has-warn"
   },
   "repository": {
     "type": "git",

--- a/test/eslint/.eslintrc.js
+++ b/test/eslint/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+    extends: '../../index',
+    root: true,
+};

--- a/test/eslint/index.js
+++ b/test/eslint/index.js
@@ -1,0 +1,15 @@
+// TypeScript Smoke Test
+
+export default class NI {
+    constructor() {
+        this._awesomeLevel = 1;
+    }
+
+    get awesome() {
+        return this._awesomeLevel > 0;
+    }
+
+    makeAwesomer() {
+        this._awesomeLevel += 1;
+    }
+}

--- a/tools/has-warn.js
+++ b/tools/has-warn.js
@@ -1,0 +1,23 @@
+const { ESLint } = require('eslint');
+
+(async () => {
+    const hasWarn = function (config) {
+        return JSON.stringify(config).indexOf('"warn"') !== -1;
+    };
+
+    const eslint = new ESLint();
+    const configEslint = await eslint.calculateConfigForFile(`${__dirname}/../test/eslint/index.js`);
+    const configTypescript = await eslint.calculateConfigForFile(`${__dirname}/../test/typescript/index.js`);
+    const configTypescriptTypechecked = await eslint.calculateConfigForFile(`${__dirname}/../test/typescript-type-checking/index.js`);
+
+    global.console.log(`Config eslint has warn?: ${hasWarn(configEslint)}`);
+    global.console.log(`Config typescript has warn?: ${hasWarn(configTypescript)}`);
+    global.console.log(`Config typescript type checking has warn?: ${hasWarn(configTypescriptTypechecked)}`);
+
+    global.console.log('Config eslint:');
+    global.console.log(JSON.stringify(configEslint, undefined, 4));
+    global.console.log('Config typescript:');
+    global.console.log(JSON.stringify(configTypescript, undefined, 4));
+    global.console.log('Config typescript type checking:');
+    global.console.log(JSON.stringify(configTypescriptTypechecked, undefined, 4));
+})();

--- a/tools/print-evaluated-rules.js
+++ b/tools/print-evaluated-rules.js
@@ -10,14 +10,16 @@ const { ESLint } = require('eslint');
     const configTypescript = await eslint.calculateConfigForFile(`${__dirname}/../test/typescript/index.js`);
     const configTypescriptTypechecked = await eslint.calculateConfigForFile(`${__dirname}/../test/typescript-type-checking/index.js`);
 
-    global.console.log(`Config eslint has warn?: ${hasWarn(configEslint)}`);
-    global.console.log(`Config typescript has warn?: ${hasWarn(configTypescript)}`);
-    global.console.log(`Config typescript type checking has warn?: ${hasWarn(configTypescriptTypechecked)}`);
-
-    global.console.log('Config eslint:');
+    global.console.log('-------- Evaluated rules:');
+    global.console.log('Evaluated eslint rules:');
     global.console.log(JSON.stringify(configEslint, undefined, 4));
-    global.console.log('Config typescript:');
+    global.console.log('Evaluated TypeScript rules:');
     global.console.log(JSON.stringify(configTypescript, undefined, 4));
-    global.console.log('Config typescript type checking:');
+    global.console.log('Evaluated TypeScript type checking rules:');
     global.console.log(JSON.stringify(configTypescriptTypechecked, undefined, 4));
+
+    global.console.log('-------- Audits:');
+    global.console.log(`Evaluated eslint rules has warn?: ${hasWarn(configEslint)}`);
+    global.console.log(`Evaluated TypeScript rules has warn?: ${hasWarn(configTypescript)}`);
+    global.console.log(`Evaluated TypeScript type checking rules has warn?: ${hasWarn(configTypescriptTypechecked)}`);
 })();

--- a/tools/print-typescript-properties.js
+++ b/tools/print-typescript-properties.js
@@ -6,7 +6,7 @@ const requiresTypeChecking = key => isTrue(plugin.rules[key].meta.docs.requiresT
 const extendsBaseRule = key => isTrue(plugin.rules[key].meta.docs.extendsBaseRule);
 const print = keys => {
     const results = {};
-    keys.forEach(key => { results[`@typescript-eslint/${key}`] = 'error'; });
+    keys.forEach(key => { results[`@typescript-eslint/${key}`] = ''; });
     global.console.log(JSON.stringify(results, null, 4));
 };
 


### PR DESCRIPTION
The `print-evaluated-rules` script is intended to be used during development to make it easier to audit different configuration settings.

The `print-evaluated-rules` script will use the eslint api to to run the lint configuration evaluation on the different smoke test files. The smoke test files should represent all of the available lint configurations. The calculated configs show the final evaluated rules for a file and make it easier to audit some behavior instead of cross-referencing all the rulesets individually (airbnb, typescript recommended, etc.).

Note: This script does help identify some rules set to warn such as [no-constant-condition](https://github.com/ni/javascript-styleguide/pull/33/checks?check_run_id=2531590851#step:10:1170) which will be addressed in a follow-up PR.