### PR TITLE
Elevate remaining warn rules and enable rules from WebPortal

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,14 +116,14 @@ module.exports = {
 
         /*
             Disallow duplicate conditions in if-else-if chain.
-            This rule does not need to be explicilty set after enabled in airbnb:
+            This rule does not need to be explicitly set after enabled in airbnb:
             https://github.com/airbnb/javascript/blob/1eadb93e377da1e56c3f91f26610e5d0a00738a9/packages/eslint-config-airbnb-base/rules/errors.js#L44
         */
         'no-dupe-else-if': 'error',
 
         /*
             Disallow assigning to imported bindings.
-            This rule does not need to be explicilty set after enabled in airbnb:
+            This rule does not need to be explicitly set after enabled in airbnb:
             https://github.com/airbnb/javascript/blob/5641278fa1df75ba3b6af2959a553bd682c0ad42/packages/eslint-config-airbnb-base/rules/errors.js#L83
         */
         'no-import-assign': 'error',
@@ -207,7 +207,7 @@ module.exports = {
 
         /*
             Disallow returning values from setters.
-            This rule does not need to be explicilty set after enabled in airbnb:
+            This rule does not need to be explicitly set after enabled in airbnb:
             https://github.com/airbnb/javascript/blob/5641278fa1df75ba3b6af2959a553bd682c0ad42/packages/eslint-config-airbnb-base/rules/errors.js#L121
         */
         'no-setter-return': 'error',

--- a/index.js
+++ b/index.js
@@ -85,6 +85,12 @@ module.exports = {
         'max-len': 'off',
 
         /*
+            JavaScript alert, confirm, and prompt functions should be used for debugging purposes only
+            as they are obtrusive and have poor customizability.
+        */
+        'no-alert': 'error',
+
+        /*
             Errors from this rule will identify issues more often than not. However, there may be
             unique exceptions, like bad third-party API design, where this rule can be disabled
             with an inline comment.
@@ -101,6 +107,26 @@ module.exports = {
             They should generally be the only statement within an `if` block and should never use labels.
         */
         'no-continue': 'off',
+
+        /*
+            Constant expressions in conditions are likely an error. Cases representing an infinite loop
+            may utilize the construct `for (;;) {}`.
+        */
+        'no-constant-condition': 'error',
+
+        /*
+            Disallow duplicate conditions in if-else-if chain.
+            This rule does not need to be explicilty set after enabled in airbnb:
+            https://github.com/airbnb/javascript/blob/1eadb93e377da1e56c3f91f26610e5d0a00738a9/packages/eslint-config-airbnb-base/rules/errors.js#L44
+        */
+        'no-dupe-else-if': 'error',
+
+        /*
+            Disallow assigning to imported bindings.
+            This rule does not need to be explicilty set after enabled in airbnb:
+            https://github.com/airbnb/javascript/blob/5641278fa1df75ba3b6af2959a553bd682c0ad42/packages/eslint-config-airbnb-base/rules/errors.js#L83
+        */
+        'no-import-assign': 'error',
 
         /*
             There may be exceptions, like array iterators, where it is appropriate to disable this
@@ -178,6 +204,13 @@ module.exports = {
                 selector: 'WithStatement',
                 message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
             }],
+
+        /*
+            Disallow returning values from setters.
+            This rule does not need to be explicilty set after enabled in airbnb:
+            https://github.com/airbnb/javascript/blob/5641278fa1df75ba3b6af2959a553bd682c0ad42/packages/eslint-config-airbnb-base/rules/errors.js#L121
+        */
+        'no-setter-return': 'error',
 
         /**
             Underscore prefixes are permitted only to indicate fields that are for private internal


### PR DESCRIPTION
This PR enables rules from two investigations:
1. The PR #33 added a script to evaluate all rules that evaluate to a "warn" state. This PR cleans up the remaining rules that evaluate to "warn" and changes them to error.
2. When WebPortal was migrated from tslint to eslint using the ni eslint rules there were [several rules not covered by this ruleset](https://ni.visualstudio.com/DevCentral/_git/op-web-portal/pullrequest/158284). It turns out all of those rules will be enabled in future versions of the airbnb ruleset. This change enables those rules preemptively to avoid loss of rule coverage migrating from tslint to eslint.