### PR TITLE
Configure no-unused-vars to catch more unused function arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ module.exports = {
             allowSamePrecedence: true
         }],
 
-        /**
+        /*
             This rule disallows assigning to function parameters; function parameters are
             treated as const bindings. Some more readable or type-safe alternatives to
             parameter assignment are:
@@ -161,7 +161,7 @@ module.exports = {
          */
         'no-param-reassign': ['error', { props: false }],
 
-        /**
+        /*
             Prefer the '+=' operator. Allow unary operators in for loops, because it is a common
             pattern.
          */
@@ -212,7 +212,7 @@ module.exports = {
         */
         'no-setter-return': 'error',
 
-        /**
+        /*
             Underscore prefixes are permitted only to indicate fields that are for private internal
             use. Trailing or prefixed underscores that signify other use cases are not allowed.
             Different guidelines may exist for languages that support private fields, such as
@@ -220,6 +220,13 @@ module.exports = {
             fields changes in the JavaScript ecosystem.
          */
         'no-underscore-dangle': 'off',
+
+        /*
+            Unused variables are not allowed as they're usually an indication of a programming error.
+            In situations where they are required like unused callback function arguments,
+            indicate that the unused variable is intentional by pre-pending its name with _.
+        */
+        'no-unused-vars': ['error', { vars: 'all', args: 'all', argsIgnorePattern: '^_', ignoreRestSiblings: true }],
 
         /*
             Migrating from var is not trivial, so there may be exceptions for older projects.

--- a/lib/typescript-extensions.js
+++ b/lib/typescript-extensions.js
@@ -129,9 +129,9 @@ module.exports = {
             allowTaggedTemplates: false,
         }],
 
-        // Defined by Airbnb
+        // Defined by NI
         'no-unused-vars': 'off',
-        '@typescript-eslint/no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: true }],
+        '@typescript-eslint/no-unused-vars': ['error', { vars: 'all', args: 'all', argsIgnorePattern: '^_', ignoreRestSiblings: true }],
 
         // Defined by NI
         'no-use-before-define': 'off',


### PR DESCRIPTION
# Justification
Closes #32. We want to catch unused vars even when they are function arguments.

# Implementation
In both the JS and TS config change `no-unused-vars` config to:
 - error on all unused function arguments, not just arguments after the used ones
 - allow suppressing the error by prefixing the variable name with an underscore

I investigated providing a custom error but this rule doesn't support that. The default error is fairly informative: "'bar' is defined but never used. Allowed unused args must match /^_/u  no-unused-vars". Furthermore the VSCode autofixer suggestion list includes "Prefix with underscore" so I think the workaround is plenty discoverable.

I also made the comment style more consistent by removing a few `**`s.

# Testing
Locally added unused parameters to both JS and TS test files and verified that they were flagged by the linter unless prefixed with an underscore.