### PR TITLE
Override non-recommended rules in the Angular configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ configure ESLint for Angular projects** especially when migrating from TSLint. [
     ```bash
     ng g @angular-eslint/schematics:convert-tslint-to-eslint <PROJECT NAME>
     ```
+4. Enable these application-specific rules if your application uses a specific prefix for components or pipes.
+    - [@angular-eslint/component-selector](http://codelyzer.com/rules/component-selector)
+    - [@angular-eslint/pipe-prefix](http://codelyzer.com/rules/pipe-prefix)
 
 ## Usage
 

--- a/angular-template.js
+++ b/angular-template.js
@@ -7,5 +7,51 @@ module.exports = {
             Overrides to Angular template recommended rules:
             https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin-template/src/configs/recommended.json
         */
+
+        /*
+            Overrides to Angular rules outside of the recommended configuration:
+        */
+
+        /*
+            There currently isn't an NI organization wide requirement to enforce accessibility in applications. These
+            rules should be considered if individual applications prioritize it. They may be enabled in the future as
+            the priority of accessibility increases.
+
+            '@angular-eslint/template/accessibility-alt-text': 'error',
+            '@angular-eslint/template/accessibility-elements-content': 'error',
+            '@angular-eslint/template/accessibility-label-has-associated-control': 'error',
+            '@angular-eslint/template/accessibility-table-scope': 'error',
+            '@angular-eslint/template/click-events-have-key-events': 'error',
+            '@angular-eslint/template/mouse-events-have-key-events': 'error',
+            '@angular-eslint/template/no-autofocus': 'error',
+            '@angular-eslint/template/no-positive-tabindex': 'error'
+        */
+
+        '@angular-eslint/template/accessibility-valid-aria': 'error',
+
+        '@angular-eslint/template/conditional-complexity': 'error',
+
+        '@angular-eslint/template/cyclomatic-complexity': 'error',
+
+        /*
+            Enable this rule by default to enforce internationalization for existing applications that are localized
+            and new applications in the chance that they'll need to be localized in the future. Disable this rule
+            if an application will never be localized.
+        */
+        '@angular-eslint/template/i18n': ['error', { checkText: true }],
+
+        '@angular-eslint/template/no-any': 'error',
+
+        /*
+            When considering efficient bindings use memoization and pipes. Avoid heavy array iteratoration, nested
+            function calls, and calls into uncontrolled third-party imports. However, there are many cases where a
+            function call significantly improves template readability and has no impact on performance—where a 1ms
+            execution is imperceivable for users.
+        */
+        '@angular-eslint/template/no-call-expression': 'off',
+
+        '@angular-eslint/template/no-distracting-elements': 'error',
+
+        '@angular-eslint/template/no-duplicate-attributes': 'error'
     }
 };

--- a/angular.js
+++ b/angular.js
@@ -32,5 +32,41 @@ module.exports = {
             Overrides to Angular extra recommended rules:
             https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/src/configs/recommended--extra.json
         */
+
+        /*
+            Overrides to Angular rules outside of the recommended configuration:
+        */
+
+        /*
+            Extract templates and styles into a separate files. In rare cases, allow for inline templates of a few
+            elements with attributes and three minimal CSS declarations.
+        */
+        '@angular-eslint/component-max-inline-declarations': ['error', { animations: 15, styles: 15, template: 15 }],
+
+        '@angular-eslint/contextual-decorator': 'error',
+
+        /*
+            Do not require a directive to select an element or attribute exclusively, because there are valid use cases
+            for both.
+        */
+        '@angular-eslint/directive-selector': 'off',
+
+        '@angular-eslint/no-attribute-decorator': 'error',
+
+        '@angular-eslint/no-lifecycle-call': 'error',
+        '@angular-eslint/no-pipe-impure': 'error',
+        '@angular-eslint/no-queries-metadata-property': 'error',
+        '@angular-eslint/pipe-prefix': 'error',
+        '@angular-eslint/relative-url-prefix': 'error',
+        '@angular-eslint/use-component-selector': 'error',
+        '@angular-eslint/use-component-view-encapsulation': 'error',
+
+        /*
+            Provide root services with the application root injector in the Injectable decorator. However, NgModule
+            providers are frequently preferred for non-root, module scoped services in applications where tree-shaking
+            is usually irrelevant. Additionally, libraries commonly export services from modules in order to manage
+            dependencies. Consider enabling this rule for libraries to ensure proper tree-shaking when appropriate.
+        */
+        '@angular-eslint/use-injectable-provided-in': 'off'
     }
 };


### PR DESCRIPTION
- Override non-recommended rules in the Angular configuration.

Notes

- All of the non-recommended rules are temporarily defined here so that their configurations can be seen.
- The tests are currently failing, because they violate one of the non-recommended rules.
- To alleviate the difficulty of navigating the source code among many comments, a review containing a comment per rule has already been started.
- Once the evaluation is complete, I will merge our overrides and remove the rest.

Linted and tested