### PR TITLE
Add configurations for the no-default-export and prefer-default-export import rules.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
     extends: './index',
+    rules: {
+        'import/no-default-export': 'error'
+    }
 };

--- a/index.js
+++ b/index.js
@@ -61,6 +61,23 @@ module.exports = {
         }],
 
         /*
+            With prefer-default-export disabled, disallow default exports and prefer named exports to enforce consistency,
+            consistent names, require more explicit renaming, and reduce the effort spent refactoring. Multi-export files are
+            expected, and a trend to prefer named imports was seen in practice.
+        */
+        'import/no-default-export': 'error',
+
+        /*
+            The primary argument for default exports, promoting single export files, was not experienced in practice.
+            Developers were not compelled to exercise this practice, and instead, found defining a default when there is only
+            one export to be counterintuitive. While defining a class per file is recommended, multiple exports are not
+            disallowed. It was also found that another benefit, renaming an export doesn't affect imports, is usually
+            irrelevant, because the import and export names are preferred to be the same. See no-default-export for more
+            information.
+        */
+        'import/prefer-default-export': 'off',
+
+        /*
             This indentation size is used to promote consistency.
         */
         indent: ['error', 4],

--- a/test/angular/index.ts
+++ b/test/angular/index.ts
@@ -10,6 +10,6 @@ import { Component, Input } from '@angular/core';
         }
     `]
 })
-export default class AppComponent {
+export class AppComponent {
     @Input() public name = 'Angular';
 }

--- a/test/eslint/index.js
+++ b/test/eslint/index.js
@@ -1,6 +1,6 @@
 // TypeScript Smoke Test
 
-export default class NI {
+export class NI {
     constructor() {
         this._awesomeLevel = 1;
     }

--- a/test/typescript-type-checking/index.ts
+++ b/test/typescript-type-checking/index.ts
@@ -1,6 +1,6 @@
 // TypeScript Smoke Test
 
-export default class NI {
+export class NI {
     private _awesomeLevel = 1;
 
     public get awesome(): boolean {

--- a/test/typescript/index.ts
+++ b/test/typescript/index.ts
@@ -1,6 +1,6 @@
 // TypeScript Smoke Test
 
-export default class NI {
+export class NI {
     private _awesomeLevel = 1;
 
     public get awesome(): boolean {


### PR DESCRIPTION
- Disable prefer-default-export.
- Enable no-default-export

Notes:
- Closes #39 .
- Consider adding a note to the README about reversing this configuration for CommonJS applications.

Linted and tested