### PR TITLE
Add docs for unbound-method

### DIFF
--- a/typescript-requiring-type-checking.js
+++ b/typescript-requiring-type-checking.js
@@ -50,7 +50,7 @@ module.exports = {
                     // Bad, removeEventListener isn't removing the original handler
                     elt.addEventListener('click', event => this.clickHandler());
                     elt.removeEventListener('click', event => this.clickHandler());
-            3. Changing the function to be static if it doesn't need to refer to the `this` instance.
+            3. If the function doesn't use `this` to refer to an instance or other static members, you can change the function to be static and the rule will ignore it.
         */
         '@typescript-eslint/unbound-method': ['error', { ignoreStatic: true }],
 

--- a/typescript-requiring-type-checking.js
+++ b/typescript-requiring-type-checking.js
@@ -50,6 +50,7 @@ module.exports = {
                     // Bad, removeEventListener isn't removing the original handler
                     elt.addEventListener('click', event => this.clickHandler());
                     elt.removeEventListener('click', event => this.clickHandler());
+            3. Changing the function to be static if it doesn't need to refer to the `this` instance.
         */
         '@typescript-eslint/unbound-method': ['error', { ignoreStatic: true }],
 

--- a/typescript-requiring-type-checking.js
+++ b/typescript-requiring-type-checking.js
@@ -24,7 +24,7 @@ module.exports = {
         /*
             This rule can be confusing if you're not familiar with JavaScript's rules for binding `this`,
             but in our experience when it reports an error it is usually indicitave of a real bug.
-            
+
             Common ways to resolve this error include:
             1. Wrapping the function with an arrow function, which establishes `this` based on the context
                the function is defined in rather than where it's called from.

--- a/typescript-requiring-type-checking.js
+++ b/typescript-requiring-type-checking.js
@@ -21,6 +21,36 @@ module.exports = {
         */
         '@typescript-eslint/prefer-regexp-exec': 'off',
 
+        /*
+            This rule can be confusing if you're not familiar with JavaScript's rules for binding `this`, 
+            but in our experience when it reports an error it is usually indicitave of a real bug.
+            
+            Common ways to resolve this error include:
+            1. Wrapping the function with an arrow function, which establishes `this` based on the context 
+               the function is defined in rather than where it's called from.
+               ```
+                    // Good, this will refer to the class where this code is defined
+                    array.sort(() => this.compare());
+
+                    // Bad, this will refer to the context where this code is invoked from
+                    array.sort(this.compare);
+                ```
+            2. For callbacks passed to `addEventListener` which need to be referenced in `removeEventListener`,
+               the arrow function should be stored in a variable since it must refer to the same instance of the function.
+               ```
+                    // Good
+                    const handler = event => this.clickHandler();
+                    elt.addEventListener('click', handler);
+                    elt.removeEventListener('click', handler);
+
+                    // Bad, violates this rule
+                    elt.addEventListener('click', this.clickHandler);
+                    elt.removeEventListener('click', this.clickHandler);
+
+                    // Bad, removeEventListener isn't removing the original handler
+                    elt.addEventListener('click', event => this.clickHandler());
+                    elt.removeEventListener('click', event => this.clickHandler());
+        */
         '@typescript-eslint/unbound-method': ['error', { ignoreStatic: true }],
 
         /*

--- a/typescript-requiring-type-checking.js
+++ b/typescript-requiring-type-checking.js
@@ -22,11 +22,11 @@ module.exports = {
         '@typescript-eslint/prefer-regexp-exec': 'off',
 
         /*
-            This rule can be confusing if you're not familiar with JavaScript's rules for binding `this`, 
+            This rule can be confusing if you're not familiar with JavaScript's rules for binding `this`,
             but in our experience when it reports an error it is usually indicitave of a real bug.
             
             Common ways to resolve this error include:
-            1. Wrapping the function with an arrow function, which establishes `this` based on the context 
+            1. Wrapping the function with an arrow function, which establishes `this` based on the context
                the function is defined in rather than where it's called from.
                ```
                     // Good, this will refer to the class where this code is defined


### PR DESCRIPTION
# Rationale

Fixing violations of the [@typescript-eslint/unbound-method](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/unbound-method.md) rule requires you to understand how `this` behaves in various situations, which is something I always have to re-teach myself. Rather than sending developers out to the web to learn how to fix violations, we should provide some guidance in our rule documentation.

# Implementation

Synthesized information from [this comment thread](https://github.com/ni/javascript-styleguide/pull/20/files#r595574910) when we initially discussed the rule and [this stackblitz](https://stackblitz.com/edit/typescript-xdrtzi) where I re-learned `this` behaviors into a comment which describes some common resolutions.