### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ configure ESLint for Angular projects** especially when migrating from TSLint. [
             '@ni/eslint-config-typescript/requiring-type-checking'
         ]
     }, {
-        files: ['*.html']
+        files: ['*.html'],
         // ...
         extends: ['@ni/eslint-config-angular/template'],
     }]


### PR DESCRIPTION
I copied the contents of this snippet into my ESLint config and noticed that it has a typo that produces a syntax error.