### PR TITLE
Don't require i18n attributes in Angular templates to specify custom IDs

### DIFF
--- a/change/@ni-eslint-config-angular-8c3ea88e-a9bd-4615-a858-8fde5119ccce.json
+++ b/change/@ni-eslint-config-angular-8c3ea88e-a9bd-4615-a858-8fde5119ccce.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Don't require i18n attributes to have custom IDs",
+  "packageName": "@ni/eslint-config-angular",
+  "email": "molly.kreis@ni.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-angular/template.js
+++ b/packages/eslint-config-angular/template.js
@@ -44,7 +44,7 @@ module.exports = {
             and new applications in the chance that they'll need to be localized in the future. Disable this rule
             if an application will never be localized.
         */
-        '@angular-eslint/template/i18n': ['error', { checkText: true }],
+        '@angular-eslint/template/i18n': ['error', { checkId: false }],
 
         /* [accessibility] */
         '@angular-eslint/template/mouse-events-have-key-events': 'off',


### PR DESCRIPTION
We don't want to require i18n attributes in Angular template to have to specify custom IDs.

The default value for _checkText_ is _true_, so we don't need to explicitly set it in our rules.