### PR TITLE
Add noUselessIndex to no-useless-path-segments

### DIFF
--- a/change/@ni-eslint-config-javascript-42bfd672-0e42-4f64-ad26-addf045e44f8.json
+++ b/change/@ni-eslint-config-javascript-42bfd672-0e42-4f64-ad26-addf045e44f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add noUselessIndex to no-useless-path-segments",
+  "packageName": "@ni/eslint-config-javascript",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7624,7 +7624,7 @@
         "@angular/core": "^12.0.0"
       },
       "devDependencies": {
-        "@ni/eslint-config-angular": "^3.3.0",
+        "@ni/eslint-config-angular": "*",
         "@types/jasminewd2": "^2.0.10"
       }
     },
@@ -7632,7 +7632,7 @@
       "name": "@ni/javascript-test",
       "version": "1.0.0",
       "devDependencies": {
-        "@ni/eslint-config-javascript": "^3.0.3"
+        "@ni/eslint-config-javascript": "*"
       }
     },
     "tests/print-evaluated-rules": {
@@ -7641,7 +7641,7 @@
       "dependencies": {
         "@angular-eslint/eslint-plugin": "*",
         "@ni/angular-test": "*",
-        "@ni/eslint-config-angular": "^3.3.0",
+        "@ni/eslint-config-angular": "*",
         "@ni/javascript-test": "*",
         "@ni/typescript-requiring-type-checking-test": "*",
         "@ni/typescript-test": "*",
@@ -7652,14 +7652,14 @@
       "name": "@ni/typescript-test",
       "version": "1.0.0",
       "devDependencies": {
-        "@ni/eslint-config-typescript": "^3.0.4"
+        "@ni/eslint-config-typescript": "*"
       }
     },
     "tests/typescript-requiring-type-checking": {
       "name": "@ni/typescript-requiring-type-checking-test",
       "version": "1.0.0",
       "devDependencies": {
-        "@ni/eslint-config-typescript": "^3.0.4"
+        "@ni/eslint-config-typescript": "*"
       }
     }
   },
@@ -8009,7 +8009,7 @@
       "version": "file:tests/angular",
       "requires": {
         "@angular/core": "^12.0.0",
-        "@ni/eslint-config-angular": "^3.3.0",
+        "@ni/eslint-config-angular": "*",
         "@types/jasminewd2": "^2.0.10"
       }
     },
@@ -8036,7 +8036,7 @@
     "@ni/javascript-test": {
       "version": "file:tests/javascript",
       "requires": {
-        "@ni/eslint-config-javascript": "^3.0.3"
+        "@ni/eslint-config-javascript": "*"
       }
     },
     "@ni/print-evaluated-rules-test": {
@@ -8044,7 +8044,7 @@
       "requires": {
         "@angular-eslint/eslint-plugin": "*",
         "@ni/angular-test": "*",
-        "@ni/eslint-config-angular": "^3.3.0",
+        "@ni/eslint-config-angular": "*",
         "@ni/javascript-test": "*",
         "@ni/typescript-requiring-type-checking-test": "*",
         "@ni/typescript-test": "*",
@@ -8054,13 +8054,13 @@
     "@ni/typescript-requiring-type-checking-test": {
       "version": "file:tests/typescript-requiring-type-checking",
       "requires": {
-        "@ni/eslint-config-typescript": "^3.0.4"
+        "@ni/eslint-config-typescript": "*"
       }
     },
     "@ni/typescript-test": {
       "version": "file:tests/typescript",
       "requires": {
-        "@ni/eslint-config-typescript": "^3.0.4"
+        "@ni/eslint-config-typescript": "*"
       }
     },
     "@nodelib/fs.scandir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,57 +127,60 @@
       "peer": true
     },
     "node_modules/@angular-eslint/builder": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-12.5.0.tgz",
-      "integrity": "sha512-abex1KdqEvUYbJqLkqhEeW4r0DuJPDzlMZYODMyBDDFTcBFYQCzLFUkhIjRNet9Vjto3Y3DbkkFUfS4DEEwjTw==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-12.6.1.tgz",
+      "integrity": "sha512-w5hkN3ZEWAQusqFnwv4MbC8TsY6Eh4pgKShAKfYA0GmqmCp3QZG1vHRbpV1Rs0WQIzoa3RRXRiIMt6STgf8SAA==",
       "peer": true,
       "dependencies": {
         "@nrwl/devkit": "12.6.0"
       },
       "peerDependencies": {
-        "@angular/cli": ">= 12.0.0 < 13.0.0",
         "eslint": "*",
         "typescript": "*"
       }
     },
+    "node_modules/@angular-eslint/bundled-angular-compiler": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-12.6.1.tgz",
+      "integrity": "sha512-m5upUwjiegTe/iPEn02ZYg/I0pKWRJkpgvQm4Odp2Bm173orpEihzCTursUxwEi1WPNlcyduh1bgjNKAPCOtkQ=="
+    },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-12.5.0.tgz",
-      "integrity": "sha512-BugzzvgghcaxHMvUFQBdu6dwB167CwiTxjIBT9KxIYYm0IY3RUKiyVQDdSs4tcwZqsyWNWuiju4ZfGPNHGjcWw==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-12.6.1.tgz",
+      "integrity": "sha512-zchuiGeaeWYEc4q3XhHcX6Q5y4MOjtt3cZY2UxOaCTaYYp9yTh6k2MuE9hj0BO6qAcQyCrLlBiHhuYCpjAPO4Q==",
       "dependencies": {
-        "@angular-eslint/utils": "12.5.0",
+        "@angular-eslint/utils": "12.6.1",
         "@typescript-eslint/experimental-utils": "4.28.2"
       },
       "peerDependencies": {
-        "@angular/compiler": ">= 12.0.0 < 13.0.0",
         "eslint": "*",
         "typescript": "*"
       }
     },
     "node_modules/@angular-eslint/eslint-plugin-template": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-12.5.0.tgz",
-      "integrity": "sha512-qvgJieWFiK61kyuGPbRWBBmsP2J/bRjYply/aAuqpctnlLnae1/+GCsosWWP/AzOlR2TvHN62j7ZW6GSxTkUOg==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-12.6.1.tgz",
+      "integrity": "sha512-sJ6r1VKhUavQ1lTH53YdGF0bX17UywU8L2I+Oy5tl4diQ50RkIr8kwmilGC483/RuTCSwcE6mYS09a65HsPwyw==",
       "peer": true,
       "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "12.6.1",
         "@typescript-eslint/experimental-utils": "4.28.2",
         "aria-query": "^4.2.2",
         "axobject-query": "^2.2.0"
       },
       "peerDependencies": {
-        "@angular/compiler": ">= 12.0.0 < 13.0.0",
         "eslint": "*",
         "typescript": "*"
       }
     },
     "node_modules/@angular-eslint/schematics": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-12.5.0.tgz",
-      "integrity": "sha512-918oLA4Z/sQl/WWzeQNPmy23VgU1fAdlqKnZmBWFE6Mrpstoa8emX9dIl4mbQT1UbS9XtzI2OglmbX2lQR0jRw==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-12.6.1.tgz",
+      "integrity": "sha512-PERmjyTNsp08w8ShKEfzcXRB8Ye4YWceFfR5WllgrMi+teOz9XmTSO62UixgqJSRCdn9ufSNMWmN3jwtGGf03w==",
       "peer": true,
       "dependencies": {
-        "@angular-eslint/eslint-plugin": "12.5.0",
-        "@angular-eslint/eslint-plugin-template": "12.5.0",
+        "@angular-eslint/eslint-plugin": "12.6.1",
+        "@angular-eslint/eslint-plugin-template": "12.6.1",
         "ignore": "5.1.8",
         "strip-json-comments": "3.1.1",
         "tmp": "0.2.1"
@@ -187,24 +190,25 @@
       }
     },
     "node_modules/@angular-eslint/template-parser": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-12.5.0.tgz",
-      "integrity": "sha512-aAcwoy0X6B2IUvuH6i0zK7leKqM1Lx3QqzFI2gyOWLIgtT81182Wm0VT+3GWwr4pudw+L6n4NhDVDvxBkRJFtA==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-12.6.1.tgz",
+      "integrity": "sha512-eoADibsywK00BR2I1YwkukN3EGWgbagRebZdOT18ajY1gtv0fzkf82RzxArxGiM52l4MQk5vnGNX6YvsRk6ZAA==",
       "peer": true,
       "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "12.6.1",
         "eslint-scope": "^5.1.0"
       },
       "peerDependencies": {
-        "@angular/compiler": ">= 12.0.0 < 13.0.0",
         "eslint": "*",
         "typescript": "*"
       }
     },
     "node_modules/@angular-eslint/utils": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-12.5.0.tgz",
-      "integrity": "sha512-h3ayDMxndrWRwX4sSe3Xs4QpGz+wIa6cAYtDKGu3H9HPlEacQCkKkTPCDy1d+993iL+9XynWIKuNCK9pX9YHgA==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-12.6.1.tgz",
+      "integrity": "sha512-v+Vl9y0hUCDRA8hFgYov3IORfD/e1AoEEL0rhznwH7hfXwbQhwDrjSZHeQ+BMh27rEz5e8LXxJGiicF3Sq8uJw==",
       "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "12.6.1",
         "@typescript-eslint/experimental-utils": "4.28.2"
       },
       "peerDependencies": {
@@ -246,18 +250,6 @@
         "node": "^12.14.1 || >=14.0.0",
         "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular/compiler": {
-      "version": "12.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.2.4.tgz",
-      "integrity": "sha512-aqX9SgUIOYwWeD9xGlyGgFRmgvebw9EE8U5Y3Dcrhui1XvxWKnmuozs3w5JVhmEn5f42XDdOas5gkI/E7+hasA==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": "^12.14.1 || >=14.0.0"
       }
     },
     "node_modules/@angular/core": {
@@ -7584,7 +7576,7 @@
     },
     "packages/eslint-config-angular": {
       "name": "@ni/eslint-config-angular",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@ni/eslint-config-typescript": "^3.0.2"
@@ -7632,7 +7624,7 @@
         "@angular/core": "^12.0.0"
       },
       "devDependencies": {
-        "@ni/eslint-config-angular": "^3.1.0",
+        "@ni/eslint-config-angular": "^3.2.0",
         "@types/jasminewd2": "^2.0.10"
       }
     },
@@ -7759,61 +7751,69 @@
       }
     },
     "@angular-eslint/builder": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-12.5.0.tgz",
-      "integrity": "sha512-abex1KdqEvUYbJqLkqhEeW4r0DuJPDzlMZYODMyBDDFTcBFYQCzLFUkhIjRNet9Vjto3Y3DbkkFUfS4DEEwjTw==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-12.6.1.tgz",
+      "integrity": "sha512-w5hkN3ZEWAQusqFnwv4MbC8TsY6Eh4pgKShAKfYA0GmqmCp3QZG1vHRbpV1Rs0WQIzoa3RRXRiIMt6STgf8SAA==",
       "peer": true,
       "requires": {
         "@nrwl/devkit": "12.6.0"
       }
     },
+    "@angular-eslint/bundled-angular-compiler": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-12.6.1.tgz",
+      "integrity": "sha512-m5upUwjiegTe/iPEn02ZYg/I0pKWRJkpgvQm4Odp2Bm173orpEihzCTursUxwEi1WPNlcyduh1bgjNKAPCOtkQ=="
+    },
     "@angular-eslint/eslint-plugin": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-12.5.0.tgz",
-      "integrity": "sha512-BugzzvgghcaxHMvUFQBdu6dwB167CwiTxjIBT9KxIYYm0IY3RUKiyVQDdSs4tcwZqsyWNWuiju4ZfGPNHGjcWw==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-12.6.1.tgz",
+      "integrity": "sha512-zchuiGeaeWYEc4q3XhHcX6Q5y4MOjtt3cZY2UxOaCTaYYp9yTh6k2MuE9hj0BO6qAcQyCrLlBiHhuYCpjAPO4Q==",
       "requires": {
-        "@angular-eslint/utils": "12.5.0",
+        "@angular-eslint/utils": "12.6.1",
         "@typescript-eslint/experimental-utils": "4.28.2"
       }
     },
     "@angular-eslint/eslint-plugin-template": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-12.5.0.tgz",
-      "integrity": "sha512-qvgJieWFiK61kyuGPbRWBBmsP2J/bRjYply/aAuqpctnlLnae1/+GCsosWWP/AzOlR2TvHN62j7ZW6GSxTkUOg==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-12.6.1.tgz",
+      "integrity": "sha512-sJ6r1VKhUavQ1lTH53YdGF0bX17UywU8L2I+Oy5tl4diQ50RkIr8kwmilGC483/RuTCSwcE6mYS09a65HsPwyw==",
       "peer": true,
       "requires": {
+        "@angular-eslint/bundled-angular-compiler": "12.6.1",
         "@typescript-eslint/experimental-utils": "4.28.2",
         "aria-query": "^4.2.2",
         "axobject-query": "^2.2.0"
       }
     },
     "@angular-eslint/schematics": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-12.5.0.tgz",
-      "integrity": "sha512-918oLA4Z/sQl/WWzeQNPmy23VgU1fAdlqKnZmBWFE6Mrpstoa8emX9dIl4mbQT1UbS9XtzI2OglmbX2lQR0jRw==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-12.6.1.tgz",
+      "integrity": "sha512-PERmjyTNsp08w8ShKEfzcXRB8Ye4YWceFfR5WllgrMi+teOz9XmTSO62UixgqJSRCdn9ufSNMWmN3jwtGGf03w==",
       "peer": true,
       "requires": {
-        "@angular-eslint/eslint-plugin": "12.5.0",
-        "@angular-eslint/eslint-plugin-template": "12.5.0",
+        "@angular-eslint/eslint-plugin": "12.6.1",
+        "@angular-eslint/eslint-plugin-template": "12.6.1",
         "ignore": "5.1.8",
         "strip-json-comments": "3.1.1",
         "tmp": "0.2.1"
       }
     },
     "@angular-eslint/template-parser": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-12.5.0.tgz",
-      "integrity": "sha512-aAcwoy0X6B2IUvuH6i0zK7leKqM1Lx3QqzFI2gyOWLIgtT81182Wm0VT+3GWwr4pudw+L6n4NhDVDvxBkRJFtA==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-12.6.1.tgz",
+      "integrity": "sha512-eoADibsywK00BR2I1YwkukN3EGWgbagRebZdOT18ajY1gtv0fzkf82RzxArxGiM52l4MQk5vnGNX6YvsRk6ZAA==",
       "peer": true,
       "requires": {
+        "@angular-eslint/bundled-angular-compiler": "12.6.1",
         "eslint-scope": "^5.1.0"
       }
     },
     "@angular-eslint/utils": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-12.5.0.tgz",
-      "integrity": "sha512-h3ayDMxndrWRwX4sSe3Xs4QpGz+wIa6cAYtDKGu3H9HPlEacQCkKkTPCDy1d+993iL+9XynWIKuNCK9pX9YHgA==",
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-12.6.1.tgz",
+      "integrity": "sha512-v+Vl9y0hUCDRA8hFgYov3IORfD/e1AoEEL0rhznwH7hfXwbQhwDrjSZHeQ+BMh27rEz5e8LXxJGiicF3Sq8uJw==",
       "requires": {
+        "@angular-eslint/bundled-angular-compiler": "12.6.1",
         "@typescript-eslint/experimental-utils": "4.28.2"
       }
     },
@@ -7842,15 +7842,6 @@
         "semver": "7.3.5",
         "symbol-observable": "4.0.0",
         "uuid": "8.3.2"
-      }
-    },
-    "@angular/compiler": {
-      "version": "12.2.4",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.2.4.tgz",
-      "integrity": "sha512-aqX9SgUIOYwWeD9xGlyGgFRmgvebw9EE8U5Y3Dcrhui1XvxWKnmuozs3w5JVhmEn5f42XDdOas5gkI/E7+hasA==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.2.0"
       }
     },
     "@angular/core": {
@@ -8018,7 +8009,7 @@
       "version": "file:tests/angular",
       "requires": {
         "@angular/core": "^12.0.0",
-        "@ni/eslint-config-angular": "^3.1.0",
+        "@ni/eslint-config-angular": "^3.2.0",
         "@types/jasminewd2": "^2.0.10"
       }
     },

--- a/packages/eslint-config-javascript/index.js
+++ b/packages/eslint-config-javascript/index.js
@@ -75,6 +75,18 @@ module.exports = {
         'import/no-default-export': 'error',
 
         /*
+            Keep path names short and consistent by avoiding unnecessary realtive path segments and consistently
+            avoiding usage of index files when possible.
+        */
+        'import/no-useless-path-segments': [
+            'error',
+            {
+                noUselessIndex: true,
+                commonjs: true
+            }
+        ],
+
+        /*
             The primary argument for default exports, promoting single export files, was not experienced in practice.
             Developers were not compelled to exercise this practice, and instead, found defining a default when there is only
             one export to be counterintuitive. While defining a class per file is recommended, multiple exports are not

--- a/packages/eslint-config-javascript/index.js
+++ b/packages/eslint-config-javascript/index.js
@@ -75,7 +75,7 @@ module.exports = {
         'import/no-default-export': 'error',
 
         /*
-            Keep path names short and consistent by avoiding unnecessary realtive path segments and consistently
+            Keep path names short and consistent by avoiding unnecessary relative path segments and consistently
             avoiding usage of index files when possible.
         */
         'import/no-useless-path-segments': [


### PR DESCRIPTION
# Justification

Found code that was mixing usages of index imports and directory imports.

For example with the following npm package file structure:
```
- src
  - awesome
    - index.ts
  - other.ts
```

Some imports within the library would use `import './awesome';` while others used `import './awesome/index';`.

In es6 modules world those resolve to two different absolute paths, ie `C:/lib/src/awesome` vs `C:/lib/src/awesome/index` so tooling that may not be aware of commonjs file resolution [may treat them as different symbols](https://github.com/psykolm22/angular-google-place/issues/29#issuecomment-360884843). This is not a concern in modern versions of tooling that I have seen but enforcing the consistency seems useful anyway for readability.

This PR copies the exisiting airbnb rule for [import/no-useless-path-segments](https://github.com/airbnb/javascript/blob/d8cb404da74c302506f91e5928f30cc75109e74d/packages/eslint-config-airbnb-base/rules/imports.js#L241) and adds the [noUselessIndex](https://github.com/import-js/eslint-plugin-import/blob/7c239fed485ea0785a96c1fa2045d96c181bb79c/docs/rules/no-useless-path-segments.md#nouselessindex) configuration.