### PR TITLE
Disable @angular-eslint/component-max-inline-declarations in tests

### DIFF
--- a/change/@ni-eslint-config-angular-d7b7362b-1d9a-4a43-8b03-f444ec709ea4.json
+++ b/change/@ni-eslint-config-angular-d7b7362b-1d9a-4a43-8b03-f444ec709ea4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Disable @angular-eslint/component-max-inline-declarations in tests",
+  "packageName": "@ni/eslint-config-angular",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-angular/index.js
+++ b/packages/eslint-config-angular/index.js
@@ -112,6 +112,12 @@ module.exports = {
             files: ['*.spec.ts'],
             rules: {
                 /*
+                    Tests often define helper components and it improves test readability if they are in the same
+                    file as the tests.
+                */
+                '@angular-eslint/component-max-inline-declarations': 'off',
+
+                /*
                     Components defined in tests are typically only used within a single test file so don't need.
                     a compontent selector.
                 */


### PR DESCRIPTION
The `@angular-eslint/component-max-inline-declarations` rule enforces that inline component templates (those written in the .ts file) can only contain a 15 lines before they should be moved to a separate file. I propose this rule should be disabled in test files since it improves test readability to have helper components in the same file as the test, even if they are longer than 15 lines. We already disable a couple related rules with similar justification (see below in the file I'm editing).

This was spurred by [this PR](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullrequest/243777?_a=files&path=/Web/Workspaces/SystemLinkShared/projects/systemlink-lib-angular/src/components/sl-toolbar/sl-toolbar.component.spec.ts) where someone disabled this rule in a test file. In this case the repo is using an older version of our ruleset so the rule was firing on smaller components, but I believe suppressing it would still be valid even if the component were larger.