### PR TITLE
Re-enable i18n in Angular smoke test

### DIFF
--- a/tests/angular/.eslintrc.js
+++ b/tests/angular/.eslintrc.js
@@ -14,10 +14,7 @@ module.exports = {
         }
     }, {
         extends: '@ni/eslint-config-angular/template',
-        files: ['*.html'],
-        rules: {
-            '@angular-eslint/template/i18n': 'off'
-        }
+        files: ['*.html']
     }],
     root: true
 };

--- a/tests/angular/index.html
+++ b/tests/angular/index.html
@@ -1,2 +1,2 @@
 <!-- Angular Template Smoke Test -->
-Hello <span [(id)]="name">{{ name }}</span>!
+<span i18n [(id)]="name">Hello {{ name }}</span>!

--- a/tests/angular/index.ts
+++ b/tests/angular/index.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 
 @Component({
     selector: 'app-root',
-    template: 'Hello <span [(id)]="name">{{name}}</span>!',
+    template: '<span i18n [(id)]="name">Hello {{name}}</span>!',
     styles: [`
         span {
             font-weight: bold;


### PR DESCRIPTION

# Pull Request

## 🤨 Rationale

Fixes #64 

## 👩‍💻 Implementation

- Updated smoke test eslint config to remove the disable
- Added the i18n attribute to the span and makes sure all text is contained in an element with an i18n attribute.

## 🧪 Testing

- Ran tests locally

## ✅ Checklist

- [x] I have updated the project documentation to reflect my changes or determined no changes are needed.