### PR TITLE
Switch to @ni/beachball-lock-update package

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,73 +1,9 @@
 const path = require('path');
-const fs = require('fs');
-const os = require('os');
-
-// Workaround for the following issues:
-// Beachball issue: https://github.com/microsoft/beachball/issues/525
-// NPM issue 1: https://github.com/npm/cli/issues/3756
-// NPM issue 2: https://github.com/npm/cli/issues/3757
-
-/**
- * Returns a beachball postbump hook implementation that bumps package
- * references specified in the root package-lock.json file during
- * beachball package version bumps.
- */
-const postbump = (_packagePath, packageName, packageVersion) => {
-    console.log(`Updating lockfile for package ${packageName} to version ${packageVersion}`);
-    const lockPath = path.resolve(__dirname, './package-lock.json');
-
-    console.log(`Lockfile to update: ${lockPath}`);
-    const lockFile = JSON.parse(fs.readFileSync(lockPath));
-
-    const isObject = function (obj) {
-        return typeof obj === 'object' && obj !== null;
-    };
-    const recurseProperties = (currentValue, path) => {
-        if (Array.isArray(currentValue)) {
-            currentValue.forEach((value, i) => recurseProperties(value, [...path, `[${i}]`]));
-        } else if (isObject(currentValue)) {
-            const keys = Object.keys(currentValue);
-            keys.forEach(key => {
-                const value = currentValue[key];
-                if (typeof value === 'string') {
-                    if (key === packageName) {
-                        // "@awesome/package": "^1.2.3-beta.4"
-                        // Note: Uses a hard coded semantic range specifier
-                        const update = `^${packageVersion}`;
-                        console.log(`Updating lockfile path (${[...path, key].join(' > ')}) to value ${update}.`);
-                        currentValue[key] = update;
-                    } else if (key === 'version' && currentValue.name === packageName) {
-                        // "name": "@awesome/package",
-                        // "version": "1.2.3-beta.4"
-                        const update = packageVersion;
-                        console.log(`Updating lockfile path (${[...path, key].join(' > ')}) to value ${update}.`);
-                        currentValue[key] = update;
-                    } else {
-                        // don't care about other string values
-                        return;
-                    }
-                } else {
-                    recurseProperties(currentValue[key], [...path, key]);
-                }
-            })
-        } else {
-            // Don't care about primitives at this point
-            // Only care about string keys on an object
-            return;
-        }
-    };
-    recurseProperties(lockFile, []);
-
-    console.log(`Serializing and writing lockfile for package ${packageName}`);
-    const updatedLockFileJSON = JSON.stringify(lockFile, null, 2) + '\n';
-    updatedLockFileJSONNewLines = updatedLockFileJSON.split('\n').join(os.EOL);
-    fs.writeFileSync(lockPath, updatedLockFileJSONNewLines);
-
-    console.log(`Updated lockfile for package ${packageName}`);
-};
+const lockPath = path.resolve(__dirname, './package-lock.json');
+const { createPostbump } = require('@ni/beachball-lock-update');
 
 module.exports = {
     hooks: {
-        postbump
+        postbump: createPostbump(lockPath)
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "tests/print-evaluated-rules"
       ],
       "devDependencies": {
+        "@ni/beachball-lock-update": "^1.0.0-beta.0",
         "beachball": "^2.21.0"
       }
     },
@@ -459,6 +460,15 @@
     "node_modules/@ni/angular-test": {
       "resolved": "tests/angular",
       "link": true
+    },
+    "node_modules/@ni/beachball-lock-update": {
+      "version": "1.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@ni/beachball-lock-update/-/beachball-lock-update-1.0.0-beta.0.tgz",
+      "integrity": "sha512-hhwZB9t/7qIxmwUA6hRbX7MEiAEPkksmVtC/gMmEcZ3X20CNdHwKMX3OTenDjf5V2o13w+7YQje2ntcTH+jFOQ==",
+      "dev": true,
+      "peerDependencies": {
+        "beachball": "^2.20.0"
+      }
     },
     "node_modules/@ni/eslint-config-angular": {
       "resolved": "packages/eslint-config-angular",
@@ -7624,7 +7634,7 @@
         "@angular/core": "^12.0.0"
       },
       "devDependencies": {
-        "@ni/eslint-config-angular": "^3.3.1",
+        "@ni/eslint-config-angular": "*",
         "@types/jasminewd2": "^2.0.10"
       }
     },
@@ -7632,7 +7642,7 @@
       "name": "@ni/javascript-test",
       "version": "1.0.0",
       "devDependencies": {
-        "@ni/eslint-config-javascript": "^3.1.0"
+        "@ni/eslint-config-javascript": "*"
       }
     },
     "tests/print-evaluated-rules": {
@@ -7641,7 +7651,7 @@
       "dependencies": {
         "@angular-eslint/eslint-plugin": "*",
         "@ni/angular-test": "*",
-        "@ni/eslint-config-angular": "^3.3.1",
+        "@ni/eslint-config-angular": "*",
         "@ni/javascript-test": "*",
         "@ni/typescript-requiring-type-checking-test": "*",
         "@ni/typescript-test": "*",
@@ -7652,14 +7662,14 @@
       "name": "@ni/typescript-test",
       "version": "1.0.0",
       "devDependencies": {
-        "@ni/eslint-config-typescript": "^3.0.5"
+        "@ni/eslint-config-typescript": "*"
       }
     },
     "tests/typescript-requiring-type-checking": {
       "name": "@ni/typescript-requiring-type-checking-test",
       "version": "1.0.0",
       "devDependencies": {
-        "@ni/eslint-config-typescript": "^3.0.5"
+        "@ni/eslint-config-typescript": "*"
       }
     }
   },
@@ -8009,9 +8019,16 @@
       "version": "file:tests/angular",
       "requires": {
         "@angular/core": "^12.0.0",
-        "@ni/eslint-config-angular": "^3.3.1",
+        "@ni/eslint-config-angular": "*",
         "@types/jasminewd2": "^2.0.10"
       }
+    },
+    "@ni/beachball-lock-update": {
+      "version": "1.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@ni/beachball-lock-update/-/beachball-lock-update-1.0.0-beta.0.tgz",
+      "integrity": "sha512-hhwZB9t/7qIxmwUA6hRbX7MEiAEPkksmVtC/gMmEcZ3X20CNdHwKMX3OTenDjf5V2o13w+7YQje2ntcTH+jFOQ==",
+      "dev": true,
+      "requires": {}
     },
     "@ni/eslint-config-angular": {
       "version": "file:packages/eslint-config-angular",
@@ -8036,7 +8053,7 @@
     "@ni/javascript-test": {
       "version": "file:tests/javascript",
       "requires": {
-        "@ni/eslint-config-javascript": "^3.1.0"
+        "@ni/eslint-config-javascript": "*"
       }
     },
     "@ni/print-evaluated-rules-test": {
@@ -8044,7 +8061,7 @@
       "requires": {
         "@angular-eslint/eslint-plugin": "*",
         "@ni/angular-test": "*",
-        "@ni/eslint-config-angular": "^3.3.1",
+        "@ni/eslint-config-angular": "*",
         "@ni/javascript-test": "*",
         "@ni/typescript-requiring-type-checking-test": "*",
         "@ni/typescript-test": "*",
@@ -8054,13 +8071,13 @@
     "@ni/typescript-requiring-type-checking-test": {
       "version": "file:tests/typescript-requiring-type-checking",
       "requires": {
-        "@ni/eslint-config-typescript": "^3.0.5"
+        "@ni/eslint-config-typescript": "*"
       }
     },
     "@ni/typescript-test": {
       "version": "file:tests/typescript",
       "requires": {
-        "@ni/eslint-config-typescript": "^3.0.5"
+        "@ni/eslint-config-typescript": "*"
       }
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "tests/print-evaluated-rules"
   ],
   "devDependencies": {
+    "@ni/beachball-lock-update": "^1.0.0-beta.0",
     "beachball": "^2.21.0"
   }
 }


### PR DESCRIPTION
Addresses discussion from PR https://github.com/ni/javascript-styleguide/pull/77#discussion_r780428089

Removes the beachball lock update script copied from nimble with a version published in the npm registry. The script is a workaround for an issue described in the package README: https://www.npmjs.com/package/@ni/beachball-lock-update