### PR TITLE
Require curly braces for all blocks

### DIFF
--- a/change/@ni-eslint-config-javascript-3e1bcdb1-a1ce-4b72-b8e6-5a7f3b96bcaf.json
+++ b/change/@ni-eslint-config-javascript-3e1bcdb1-a1ce-4b72-b8e6-5a7f3b96bcaf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Require curly braces for all blocks",
+  "packageName": "@ni/eslint-config-javascript",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-javascript/index.js
+++ b/packages/eslint-config-javascript/index.js
@@ -35,6 +35,11 @@ module.exports = {
         'comma-dangle': ['error', 'only-multiline'],
 
         /*
+            Require curly braces {} for all blocks (e.g. if, else, while).
+        */
+        curly: ['error', 'all'],
+
+        /*
             'default-case' Airbnb rule configuration notes:
             Always provide a `default` case in `switch` statements.
             If the default case is logically unreachable, throw an Error.

--- a/packages/eslint-config-javascript/index.js
+++ b/packages/eslint-config-javascript/index.js
@@ -21,6 +21,13 @@ module.exports = {
         'arrow-parens': ['error', 'as-needed'],
 
         /*
+            Use the "one true brace style" in which in which the opening brace of a block is placed 
+            on the same line as its corresponding statement or declaration (this matches Airbnb).
+            Also require the body within the braces to be on a new line.
+        */
+        'brace-style': ['error', '1tbs', { allowSingleLine: false }],
+
+        /*
             A method's use of the this keyword does not always dictate that it should be static,
             particularly when the class must satisfy a derived interface or the caller has an
             instance. However, there are other cases, like when functionality is required without

--- a/tests/javascript/index.js
+++ b/tests/javascript/index.js
@@ -1,4 +1,4 @@
-// TypeScript Smoke Test
+// JavaScript Smoke Test
 
 export class NI {
     constructor() {


### PR DESCRIPTION
# Justification

Fixes #86.

# Implementation

Enable the [curly](https://eslint.org/docs/rules/curly) ESLint rule.

# Testing

Manually modified test files within the repo and verified that lint errors are reported for both JS and TS code if you have an `if` without braces.