### PR TITLE
Require curly braces for all blocks

### DIFF
--- a/change/@ni-eslint-config-javascript-cb28aff1-5da9-431b-b79f-c0c9abb39c0c.json
+++ b/change/@ni-eslint-config-javascript-cb28aff1-5da9-431b-b79f-c0c9abb39c0c.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Require curly braces and newlines for all blocks",
+  "comment": "Require curly braces and newlines for all blocks. This modifies the configuration for rules `brace-style` and `curly`.",
   "packageName": "@ni/eslint-config-javascript",
   "email": "jattasNI@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@ni-eslint-config-javascript-cb28aff1-5da9-431b-b79f-c0c9abb39c0c.json
+++ b/change/@ni-eslint-config-javascript-cb28aff1-5da9-431b-b79f-c0c9abb39c0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Require curly braces and newlines for all blocks",
+  "packageName": "@ni/eslint-config-javascript",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-eslint-config-typescript-18df4f7e-7e3d-4bfa-b0b2-e3a25471f744.json
+++ b/change/@ni-eslint-config-typescript-18df4f7e-7e3d-4bfa-b0b2-e3a25471f744.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Require curly braces and newlines for all blocks",
+  "packageName": "@ni/eslint-config-typescript",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-eslint-config-typescript-18df4f7e-7e3d-4bfa-b0b2-e3a25471f744.json
+++ b/change/@ni-eslint-config-typescript-18df4f7e-7e3d-4bfa-b0b2-e3a25471f744.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Require curly braces and newlines for all blocks",
+  "comment": "Require curly braces and newlines for all blocks.  This modifies the configuration for rules `brace-style`/`@typescript-eslint/brace-style` and `curly`.",
   "packageName": "@ni/eslint-config-typescript",
   "email": "jattasNI@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/eslint-config-javascript/index.js
+++ b/packages/eslint-config-javascript/index.js
@@ -21,6 +21,13 @@ module.exports = {
         'arrow-parens': ['error', 'as-needed'],
 
         /*
+            Use the "one true brace style" in which in which the opening brace of a block is placed 
+            on the same line as its corresponding statement or declaration (this matches Airbnb).
+            Also require the body within the braces to be on a new line.
+        */
+        'brace-style': ['error', '1tbs', { allowSingleLine: false }],
+
+        /*
             A method's use of the this keyword does not always dictate that it should be static,
             particularly when the class must satisfy a derived interface or the caller has an
             instance. However, there are other cases, like when functionality is required without
@@ -33,6 +40,11 @@ module.exports = {
             may be used if preferred.
         */
         'comma-dangle': ['error', 'only-multiline'],
+
+        /*
+            Require curly braces {} for all blocks (e.g. if, else, while).
+        */
+        curly: ['error', 'all'],
 
         /*
             'default-case' Airbnb rule configuration notes:

--- a/packages/eslint-config-typescript/lib/extensions.js
+++ b/packages/eslint-config-typescript/lib/extensions.js
@@ -12,9 +12,9 @@ module.exports = {
               JavaScript / Airbnb configuration.
         */
 
-        // Defined by Airbnb
+        // Defined by NI
         'brace-style': 'off',
-        '@typescript-eslint/brace-style': ['error', '1tbs', { allowSingleLine: true }],
+        '@typescript-eslint/brace-style': ['error', '1tbs', { allowSingleLine: false }],
 
         // Defined by NI
         'comma-dangle': 'off',

--- a/tests/javascript/index.js
+++ b/tests/javascript/index.js
@@ -1,4 +1,4 @@
-// TypeScript Smoke Test
+// JavaScript Smoke Test
 
 export class NI {
     constructor() {


### PR DESCRIPTION
# Justification

Fixes #86.

# Implementation

Enable the [brace-style](https://eslint.org/docs/latest/rules/brace-style) and [curly](https://eslint.org/docs/rules/curly) ESLint rules to match the decision described in the issue linked above. Now braces need to be present and the body must be on a new line:
```ts
// allowed
if (foo) {
    doSomething();
}

// disallowed
if (foo) { doSomething(); }
if (foo) doSomething();
if (foo) 
    doSomething();
```

# Testing

Manually modified test files within the repo and verified that lint errors are reported for both JS and TS code if you have an `if` without braces.