### PR TITLE
Add CONTRIBUTING docs to describe current branching workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,10 @@ The goal of the smoke tests is basic validation that the eslint configurations c
 
 ## Release workflow
 
+### Creating a pull request
+
+Currently the repository only supports contributions by creating a branch and pull request (we hope to support a fork-pull workflow soon). Not all users can create a branch in this repo; contact @rajsite to be granted the necessary privileges.
+
 ### Beachball change file
 
 This repository uses [beachball](https://microsoft.github.io/beachball/) to automate publishing its packages to NPM. The basic workflow is as follows:


### PR DESCRIPTION
# Justification

Currently the only way to contribute to the repo is by creating a branch and doing a PR but Trevor and I both accidentally tried using the fork-pull workflow. We should document this for now (and hopefully fix it soon).

# Implementation

Add docs to CONTRIBUTING.md