### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/discussion--bug-report--or-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/discussion--bug-report--or-feature-request.md
@@ -1,0 +1,16 @@
+---
+name: Discussion, bug report, or feature request
+about: Create an issue to help us improve
+title: ''
+labels: triage
+assignees: ''
+
+---
+
+**Describe the issue**
+We encourage you to file an issue if you're not happy with the way a rule is behaving. Please include relevant information like:
+- the name of the rule and a link to its docs
+- a code snippet that would be impacted by the rule change (before and after)
+- a link to code that would be impacted or projects that have already adopted different configuration
+
+We also welcome issues for general discussion, bug reports, or feature requests.


### PR DESCRIPTION
Adding an issue template so that we can add the `triage` label automatically and so that reporters have some idea of the information we'd like to see.