### PR TITLE
Loosen @typescript-eslint/naming-convention to allow properties with custom-element-names

### DIFF
--- a/change/@ni-eslint-config-typescript-0b8f0900-ab2e-43a8-9a80-2133141f33e0.json
+++ b/change/@ni-eslint-config-typescript-0b8f0900-ab2e-43a8-9a80-2133141f33e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "@typescript-eslint/naming-convention now allows properties with custom-element-style-names, commonly used in HTMLElementNameTagMap interfaces",
+  "packageName": "@ni/eslint-config-typescript",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-typescript/requiring-type-checking.js
+++ b/packages/eslint-config-typescript/requiring-type-checking.js
@@ -53,13 +53,23 @@ module.exports = {
         */
 
         /*
-            The default configuration for this rule requires that enum members
-            follow the camelCase style, which doesn't match the existing convention
-            within NI and the broader TS community to use PascalCase. The rest of the
-            configuration is identitical to the default.
+            Most of this configuration is identitical to the default with exceptions called out in comments below
         */
         '@typescript-eslint/naming-convention': [
             'error',
+            // Allow properties with custom-element-names, commonly used in HTMLElementNameTagMap
+            {
+                selector: 'property',
+                format: null,
+                filter: {
+                    // custom element regex from https://html-validate.org/rules/element-name.html
+                    regex: '[a-z][a-z0-9\\-._]*-[a-z0-9\\-._]*$',
+                    match: true
+                }
+            },
+            // The default configuration for this rule requires that enum members
+            // follow the camelCase style, which doesn't match the existing convention
+            // within NI and the broader TS community to use PascalCase.
             {
                 selector: 'enumMember',
                 format: ['PascalCase'],

--- a/packages/eslint-config-typescript/requiring-type-checking.js
+++ b/packages/eslint-config-typescript/requiring-type-checking.js
@@ -62,8 +62,8 @@ module.exports = {
                 selector: 'property',
                 format: null,
                 filter: {
-                    // custom element regex from https://html-validate.org/rules/element-name.html
-                    regex: '[a-z][a-z0-9\\-._]*-[a-z0-9\\-._]*$',
+                    // custom element regex adapted from https://html-validate.org/rules/element-name.html
+                    regex: '^[a-z][a-z0-9\\-._]*-[a-z0-9\\-._]*$',
                     match: true
                 }
             },


### PR DESCRIPTION
# Justification

Fixes #111.

# Implementation

Based off the third example in the rule's documentation under [Ignore properties that require quotes](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/naming-convention.md#ignore-properties-that-require-quotes), I am using a regex to match properties that follow the lower-hyphen-case naming convention of custom elements, and turning off format checks for properties that match.

# Testing

Locally tried these cases with the results described in the comments.

```ts
declare global {
    interface HTMLElementTagNameMap {
        'valid-custom-element': NI; // passes because of new configuration
        'valid-custom-element2': NI; // passes because of new configuration
        '2invalid-custom-element': NI; // fails because custom-element regex requires starting with a-z

        'nohyphen': NI; // passes because camelCase (with no capitals) is allowed by original configuration
        'noHyphen': NI; // passes because camelCase is allowed by original configuration
        camelCase: NI; // passes because camelCase is allowed by original configuration

        'Capital-Custom-Element': NI; // fails because PascalCase is disallowed by original configuration and new regex only matches lower case
        'capital-Custom-Element': NI; // fails because PascalCase is disallowed by original configuration and new regex only matches lower case
        PascalCase: NI; // fails because PascalCase is disallowed by original configuration
    }
}
```

Also did some testing in nimble and SystemLinkShared with locally built packages. This allows us to get rid of a global suppression in nimble and only add one inline suppression. It doesn't really help with SystemLinkShared because the one place that uses this pattern is an older library that has a custom `naming-convention` configuration so the one from the styleguide doesn't apply. However we should be able to copy the same pattern from this PR into that custom configuration.