### PR TITLE
Disable no-await-in-loop for Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ configure ESLint for Angular projects**.
 
 Extend `@ni/eslint-config-playwright` and `@ni/eslint-config-playwright/requiring-type-checking` in the [ESLint configuration](https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats). Set the `parserOptions.project` configuration to the project's TypeScript configuration.
 
-**Note:** The Playwright configurations extend the TypeScript configurations, so it is not necessary for an application to extend them both.
+**Note:** The Playwright configurations extend the TypeScript configurations, so it is not necessary for an application to extend them both. However, the Playwright configurations should only be applied to directories that contain Playwright tests.
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -129,9 +129,11 @@ configure ESLint for Angular projects**.
 
 Extend `@ni/eslint-config-playwright` and `@ni/eslint-config-playwright/requiring-type-checking` in the [ESLint configuration](https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats). Set the `parserOptions.project` configuration to the project's TypeScript configuration.
 
-**Note:** The Playwright configurations extend the TypeScript configurations, so it is not necessary for an application to extend them both. However, the Playwright configurations should only be applied to directories that contain Playwright tests.
+**Note:** The Playwright configurations extend the TypeScript configurations, so it is not necessary for an application to extend them both. However, the Playwright configurations should only be applied to directories that contain Playwright tests and utilities.
 
 ```js
+// This is an example .eslintrc.js in a Playwright-specific directory.
+// If Playwright files are mixed with other code, use an "overrides" file pattern to match only Playwright code
 {
     extends: [
         '@ni/eslint-config-playwright',

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Extend `@ni/eslint-config-playwright` and `@ni/eslint-config-playwright/requirin
 
 ```js
 // This is an example .eslintrc.js in a Playwright-specific directory.
-// If Playwright files are mixed with other code, use an "overrides" file pattern to match only Playwright code
+// If Playwright files are mixed with other code, use an "overrides" file pattern to match only Playwright code.
 {
     extends: [
         '@ni/eslint-config-playwright',

--- a/change/@ni-eslint-config-playwright-1125d689-3a37-4a84-b8ef-19749c7339f6.json
+++ b/change/@ni-eslint-config-playwright-1125d689-3a37-4a84-b8ef-19749c7339f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disable no-await-in-loop for Playwright",
+  "packageName": "@ni/eslint-config-playwright",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-playwright/index.js
+++ b/packages/eslint-config-playwright/index.js
@@ -5,6 +5,14 @@ module.exports = {
     ],
     rules: {
         /*
+            In UI tests it is common to have a loop that performs async operations which must be sequential.
+            For example, clicking on a list of elements one after another.
+            While there are still some cases where the rule would suggest valid improvements, they are not common
+            enough to justify the noise that comes from needing to suppress it.
+        */
+        'no-await-in-loop': 'off',
+
+        /*
             Playwright marks this as recommended but configures it as 'warn'.
             Deeply nested describe blocks are likely an indication that test files are too complicated.
         */


### PR DESCRIPTION
# Justification

#123 (won't mark it fixed until we uptake this in clients and remove suppressions)

# Implementation

Add a rule configuration and docs to the `index.js` for the Playwright ruleset.

# Testing

Built package locally, imported into an SLE codebase, and verified that violations no longer need to be suppressed.