### PR TITLE
Add appearanceVariant to the list of i18n attributes to ignore.

### DIFF
--- a/change/@ni-eslint-config-angular-bf7dbc9a-74e8-4df1-a682-436e40418795.json
+++ b/change/@ni-eslint-config-angular-bf7dbc9a-74e8-4df1-a682-436e40418795.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add appearanceVariant to the list of i18n attributes to ignore.",
+  "packageName": "@ni/eslint-config-angular",
+  "email": "2351292+TrevorKarjanis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -16,6 +16,7 @@ const ignoreAttributeSets = {
         'activeid',
         'appearance',
         'appearance-variant',
+        'appearanceVariant',
         'autocomplete',
         'column-id',
         'field-name',


### PR DESCRIPTION
For whatever reason, `appearance-variant` was not working, so `appearanceVariant`, the Angular directive, is required.

Notes
- Add `appearanceVariant` to the list of i18n attributes to ignore.

Testing
- Manually verified that `appearanceVariant` is ignored