### PR TITLE
Move appearance variant to systemlink list

### DIFF
--- a/change/@ni-eslint-config-angular-5b9c7b9d-f3dc-4cd2-ae70-26717d051203.json
+++ b/change/@ni-eslint-config-angular-5b9c7b9d-f3dc-4cd2-ae70-26717d051203.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move appearanceVariant to systemlink list",
+  "packageName": "@ni/eslint-config-angular",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -16,7 +16,6 @@ const ignoreAttributeSets = {
         'activeid',
         'appearance',
         'appearance-variant',
-        'appearanceVariant',
         'autocomplete',
         'column-id',
         'field-name',
@@ -57,6 +56,9 @@ const ignoreAttributeSets = {
         'gridId',
         'loadColumnStateBehavior',
         'parentDataField',
+
+        // sl-split-button
+        'appearanceVariant',
 
         // sl-query-builder
         'dropdownWidth',


### PR DESCRIPTION
Minor follow-up to https://github.com/ni/javascript-styleguide/pull/141 to move `appearanceVariant` to the correct list.
The `sl-split-button` uses a different API from nimble currently so has a different name for the localize ignore list.

`@Input('appearance-variant') public set appearanceVariant` in nimble vs `@Input() public appearanceVariant` for sl-split-button. Note the difference in the `@Input` decorator configuration.