### PR TITLE
Add attributes used by SystemLinkShared that shouldn't trigger template/i18n

### DIFF
--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -16,7 +16,6 @@ const ignoreAttributeSets = {
         'activeid',
         'appearance',
         'appearance-variant',
-        'appearanceVariant',
         'autocomplete',
         'column-id',
         'error-text',
@@ -63,6 +62,9 @@ const ignoreAttributeSets = {
 
         // sl-query-builder
         'dropdownWidth',
+
+        // sl-split-button
+        'appearanceVariant',
 
         // native element attributes used by sl components
         'accept',

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -19,7 +19,9 @@ const ignoreAttributeSets = {
         'appearanceVariant',
         'autocomplete',
         'column-id',
+        'error-text',
         'field-name',
+        'filter-mode',
         'format',
         'icon',
         'id-field-name',
@@ -32,6 +34,7 @@ const ignoreAttributeSets = {
         'selection-mode',
         'severity',
         'slot',
+        'sort-direction',
         'theme'
     ],
     systemlink: [
@@ -60,6 +63,10 @@ const ignoreAttributeSets = {
 
         // sl-query-builder
         'dropdownWidth',
+
+        // native element attributes used by sl components
+        'accept',
+        'aria-live',
     ],
     jqx: [
         // smart-table

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -66,9 +66,6 @@ const ignoreAttributeSets = {
         // sl-query-builder
         'dropdownWidth',
 
-        // sl-split-button
-        'appearanceVariant',
-
         // native element attributes used by sl components
         'accept',
         'aria-live',


### PR DESCRIPTION
As a follow up to #140, our original list of attributes was incomplete. I'm adding the attributes that are needed to build Skyline `Web/Workspaces/SystemLinkShared`