### PR TITLE
Add another attribute needed by SystemLinkShared for template/i18n

### DIFF
--- a/change/@ni-eslint-config-angular-ab65fdd4-a268-4e38-b0a5-eb2b72909b90.json
+++ b/change/@ni-eslint-config-angular-ab65fdd4-a268-4e38-b0a5-eb2b72909b90.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add another SystemLink attribute for template/i18n",
+  "packageName": "@ni/eslint-config-angular",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -50,6 +50,7 @@ const ignoreAttributeSets = {
         'labelFieldName',
         'selectionMode',
         'slTableColumnId',
+        'widthMode',
 
         // sl-grid
         'columnSizeMode',


### PR DESCRIPTION
Same as #143 but one more attribute that I didn't discover until after polishing [the SystemLink PR uptaking this rule change](https://dev.azure.com/ni/DevCentral/_git/Skyline/pullrequest/716904)