### PR TITLE
Menu button column i18n exceptions

### DIFF
--- a/change/@ni-eslint-config-angular-f843a0d5-d347-496e-83b1-40972123d52a.json
+++ b/change/@ni-eslint-config-angular-f843a0d5-d347-496e-83b1-40972123d52a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add 'menu-slot' exception for the menu-button table column",
+  "packageName": "@ni/eslint-config-angular",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-eslint-config-angular-f843a0d5-d347-496e-83b1-40972123d52a.json
+++ b/change/@ni-eslint-config-angular-f843a0d5-d347-496e-83b1-40972123d52a.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add 'menu-slot' exception for the menu-button table column",
+  "comment": "Add 'menu-slot' i18n exception for the menu-button table column",
   "packageName": "@ni/eslint-config-angular",
   "email": "20542556+mollykreis@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -58,6 +58,7 @@ const ignoreAttributeSets = {
         'selection-mode',
         'sort-direction',
         'width-mode',
+        'menu-slot',
 
         // tabs
         'activeid',

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -54,11 +54,11 @@ const ignoreAttributeSets = {
         'key',
         'key-type',
         'label-field-name',
+        'menu-slot',
         'parent-id-field-name',
         'selection-mode',
         'sort-direction',
         'width-mode',
-        'menu-slot',
 
         // tabs
         'activeid',


### PR DESCRIPTION
The `nimble-table-column-menu-button` has a `menu-slot` attribute that should not be localized. Therefore, it needs to be added to the list of attribute exceptions.