### PR TITLE
Exempt parentIdFieldName from i18n rule

### DIFF
--- a/change/@ni-eslint-config-angular-3d89d5a4-8597-4615-b1ce-b27eae9956dd.json
+++ b/change/@ni-eslint-config-angular-3d89d5a4-8597-4615-b1ce-b27eae9956dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Exempt parentIdFieldName from i18n rule",
+  "packageName": "@ni/eslint-config-angular",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -90,6 +90,7 @@ const ignoreAttributeSets = {
         'idFieldName',
         'keyType',
         'labelFieldName',
+        'parentIdFieldName',
         'selectionMode',
         'slTableColumnId',
         'widthMode',


### PR DESCRIPTION
The `parentIdFieldName` attribute of the `sl-table` does not require translation, so add it to the exemptions.