### PR TITLE
Update node-version in build.yml from 20 to 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     # Install dependencies
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '22'
         registry-url: 'https://registry.npmjs.org'
         cache: 'npm'
     - run: npm ci


### PR DESCRIPTION
I am upgrading Node across projects that our team contributes to. We want the versions to be aligned so that developers can have consistent behaviors across pipelines and their development machines.

See also:
https://github.com/ni/nimble/pull/2364
https://dev.azure.com/ni/DevCentral/_git/Skyline/pullrequest/786732