### PR TITLE
Disable explicit member accessibility for constructors

### DIFF
--- a/change/@ni-eslint-config-typescript-b2c9d1d5-86de-4fd6-b66f-c5a696790e65.json
+++ b/change/@ni-eslint-config-typescript-b2c9d1d5-86de-4fd6-b66f-c5a696790e65.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Disable explicit-member-accessibility for ctors",
+  "packageName": "@ni/eslint-config-typescript",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-eslint-config-typescript-b2c9d1d5-86de-4fd6-b66f-c5a696790e65.json
+++ b/change/@ni-eslint-config-typescript-b2c9d1d5-86de-4fd6-b66f-c5a696790e65.json
@@ -1,7 +1,7 @@
 {
   "type": "minor",
-  "comment": "Disable explicit-member-accessibility for ctors",
+  "comment": "Disable `@typescript-eslint/explicit-member-accessibility` for constructors",
   "packageName": "@ni/eslint-config-typescript",
   "email": "jattasNI@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "minor"
 }

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -74,9 +74,12 @@ module.exports = {
         /*
             Requiring an accessibility modifier helps when creating classes to ensure the
             accessibility of a class member is intentionally decided and not relying on
-            the default of public accessibility.
+            the default of public accessibility. Constructors are omitted because they are
+            almost always public.
         */
-        '@typescript-eslint/explicit-member-accessibility': 'error',
+        '@typescript-eslint/explicit-member-accessibility': ['error',
+            { accessibility: 'explicit', overrides: { constructors: 'off' } }
+        ],
 
         /*
             All interface members should be terminated with a semicolon including single line

--- a/tests/typescript/index.ts
+++ b/tests/typescript/index.ts
@@ -3,6 +3,10 @@
 export class NI {
     private _awesomeLevel = 1;
 
+    constructor() {
+        this._awesomeLevel = 11;
+    }
+
     public get awesome(): boolean {
         return this._awesomeLevel > 0;
     }


### PR DESCRIPTION
# Rationale

Resolves #100. Constructors may now be marked `public`, `private`, or have no accessibility modifier. Previously they had to be marked `public` or `private`.

# Implementation

Set `overrides: { constructors: 'off' }` in the TS rule configuration.

# Testing

Added a constructor to the TypeScript test and verified the rule previously errored if it didn't have a modifier but now allows this.