### PR TITLE
Exempt groupableParentColumnId from i18n rule

### DIFF
--- a/change/@ni-eslint-config-angular-9ac0e40a-7052-4b98-a74f-2b443d4cb1d7.json
+++ b/change/@ni-eslint-config-angular-9ac0e40a-7052-4b98-a74f-2b443d4cb1d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Exempt groupableParentColumnId from i18n rule",
+  "packageName": "@ni/eslint-config-angular",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -86,6 +86,7 @@ const ignoreAttributeSets = {
         'decimalDigits',
         'fieldName',
         'format',
+        'groupableParentColumnId',
         'hrefFieldName',
         'idFieldName',
         'keyType',


### PR DESCRIPTION
The `groupableParentColumnId` attribute of the `sl-table` does not require translation, so add it to the exemptions.