### PR TITLE
Allow pascal-case imports and disable consistent-generic-constructors

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -46,8 +46,6 @@ module.exports = {
             https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/stylistic.ts
         */
 
-        '@typescript-eslint/consistent-generic-constructors': 'off',
-
         /*
             Overrides to Typescript rules outside of the recommended configuration:
         */

--- a/packages/eslint-config-typescript/requiring-type-checking.js
+++ b/packages/eslint-config-typescript/requiring-type-checking.js
@@ -56,6 +56,7 @@ module.exports = {
             https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/stylistic-type-checked.ts
         */
 
+        '@typescript-eslint/consistent-generic-constructors': 'off',
         '@typescript-eslint/prefer-regexp-exec': 'off',
 
         /*
@@ -85,12 +86,6 @@ module.exports = {
                 format: ['PascalCase'],
             },
             {
-                selector: 'default',
-                format: ['camelCase'],
-                leadingUnderscore: 'allow',
-                trailingUnderscore: 'allow',
-            },
-            {
                 selector: 'variable',
                 format: ['camelCase', 'UPPER_CASE'],
                 leadingUnderscore: 'allow',
@@ -99,6 +94,16 @@ module.exports = {
             {
                 selector: 'typeLike',
                 format: ['PascalCase'],
+            },
+            {
+                selector: 'import',
+                format: ['camelCase', 'PascalCase'],
+            },
+            {
+                selector: 'default',
+                format: ['camelCase'],
+                leadingUnderscore: 'allow',
+                trailingUnderscore: 'allow',
             },
         ],
 


### PR DESCRIPTION
Found two rules causing new, unwanted violations in the Nimble repo:
- `@typescript-eslint/consistent-generic-constructors` results in errors like "The generic type arguments should be specified as part of the constructor type arguments" (when only specified in the type of the variable being initialized)
   - I had tried to disable this in the prior PR, but was doing so from the wrong config. Now disabling it works.
-  `@typescript-eslint/naming-convention` now covers imported namespaces (e.g. `import * as Foo from '../foo'`), and it defaults to allowing both camel and pascal case. However, because we are configuring the `'default'` selector (which matches anything not otherwise specified) to only allow camel case, it was disallowing pascal case for those imported namespaces.