### PR TITLE
Add more cdk attributes to material options ignored by localization rule

### DIFF
--- a/change/@ni-eslint-config-angular-8730bc71-7851-4b42-ba3a-c03506e53067.json
+++ b/change/@ni-eslint-config-angular-8730bc71-7851-4b42-ba3a-c03506e53067.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add cdkDragBoundary to material options to silence @angular-eslint/template/i18n rule.",
+  "packageName": "@ni/eslint-config-angular",
+  "email": "jonathan.meyer@ni.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@ni-eslint-config-angular-8730bc71-7851-4b42-ba3a-c03506e53067.json
+++ b/change/@ni-eslint-config-angular-8730bc71-7851-4b42-ba3a-c03506e53067.json
@@ -2,6 +2,6 @@
   "type": "patch",
   "comment": "Add cdkDragBoundary to material options to silence @angular-eslint/template/i18n rule.",
   "packageName": "@ni/eslint-config-angular",
-  "email": "jonathan.meyer@ni.com",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
   "dependentChangeType": "patch"
 }

--- a/change/@ni-eslint-config-angular-8730bc71-7851-4b42-ba3a-c03506e53067.json
+++ b/change/@ni-eslint-config-angular-8730bc71-7851-4b42-ba3a-c03506e53067.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add cdkDragBoundary to material options to silence @angular-eslint/template/i18n rule.",
+  "comment": "Add more cdk attributes to material options to silence @angular-eslint/template/i18n rule.",
   "packageName": "@ni/eslint-config-angular",
   "email": "26874831+atmgrifter00@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -121,6 +121,7 @@ const ignoreAttributeSets = {
     material: [
         'cdkDragPreviewContainer',
         'cdkDragLockAxis',
+        'cdkDragBoundary',
         'floatLabel',
         'fontIcon',
         'fontSet',

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -123,7 +123,7 @@ const ignoreAttributeSets = {
         'cdkDragLockAxis',
         'cdkDragPreviewContainer',
         'cdkDragPreviewClass',
-        'cdkDragRootElement'
+        'cdkDragRootElement',
         'floatLabel',
         'fontIcon',
         'fontSet',

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -119,9 +119,11 @@ const ignoreAttributeSets = {
         'fieldsMode'
     ],
     material: [
-        'cdkDragPreviewContainer',
-        'cdkDragLockAxis',
         'cdkDragBoundary',
+        'cdkDragLockAxis',
+        'cdkDragPreviewContainer',
+        'cdkDragPreviewClass',
+        'cdkDragRootElement'
         'floatLabel',
         'fontIcon',
         'fontSet',


### PR DESCRIPTION
Added 'cdkDragBoundary' after the last PR, only to find it, too, resulted in the same linting rule violation.
