### PR TITLE
Add Spright chat attribute to Angular i18n ignore list

### DIFF
--- a/change/@ni-eslint-config-angular-4b5501f1-828c-4b7b-a182-a337b222fe03.json
+++ b/change/@ni-eslint-config-angular-4b5501f1-828c-4b7b-a182-a337b222fe03.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add Spright chat attribute to i18n ignore list",
+  "packageName": "@ni/eslint-config-angular",
+  "email": "jattasNI@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -77,6 +77,10 @@ const ignoreAttributeSets = {
         'queryParamsHandling'
 
     ],
+    spright: [
+        // chat
+        'message-type'
+    ],
     systemlink: [
         // sl-workspace-selector
         'action',


### PR DESCRIPTION
## Problem

We keep a list of Nimble attributes that shouldn't trigger the i18n lint rule. The new Spright chat components didn't appear in this list so once we create Angular wrappers they would incorrectly trigger that rule.

## Implementation

Add a new section for Spright components and add the `message-type` attribute to that section.