### PR TITLE
Add 'data-telemetry' to support telemetry use-cases.

### DIFF
--- a/change/@ni-eslint-config-angular-fea9e83c-df22-4dad-b8d1-ba40d14e7b27.json
+++ b/change/@ni-eslint-config-angular-fea9e83c-df22-4dad-b8d1-ba40d14e7b27.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add 'data-telemetry-id' to support telemetry use-cases.",
+  "packageName": "@ni/eslint-config-angular",
+  "email": "jonathan.meyer@ni.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -21,7 +21,7 @@ const ignoreAttributeSets = {
         // Not possible for Angular i18n to handle meta tags yet
         // https://github.com/angular/angular-cli/issues/8947
         'meta[content]',
-        'data-telemetry-id'
+        'data-telemetry'
     ],
     nimble: [
         // shared

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -20,8 +20,7 @@ const ignoreAttributeSets = {
         'sizes',
         // Not possible for Angular i18n to handle meta tags yet
         // https://github.com/angular/angular-cli/issues/8947
-        'meta[content]',
-        'data-telemetry'
+        'meta[content]'
     ],
     nimble: [
         // shared
@@ -83,6 +82,9 @@ const ignoreAttributeSets = {
         'message-type'
     ],
     systemlink: [
+        // gainsights telemetry
+        'data-telemetry',
+
         // sl-workspace-selector
         'action',
 

--- a/packages/eslint-config-angular/template/options.js
+++ b/packages/eslint-config-angular/template/options.js
@@ -20,7 +20,8 @@ const ignoreAttributeSets = {
         'sizes',
         // Not possible for Angular i18n to handle meta tags yet
         // https://github.com/angular/angular-cli/issues/8947
-        'meta[content]'
+        'meta[content]',
+        'data-telemetry-id'
     ],
     nimble: [
         // shared


### PR DESCRIPTION
Adding the `data-telemetry` attribute to enable expected telemetry support in SLE.