### PR TITLE
Add Ok fv attribute ignores to angular eslint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,9 @@
 
 # These owners will be the default owners for everything in the repo.
 * @jattasNI @rajsite
+
+# Specific content owners
+/**/fv/** @jattasNI @fredvisser
+
+# Change files don't need explicit reviewers
+/change

--- a/change/@ni-eslint-config-angular-0fb9c127-1ff4-4c09-8790-86ea0527226c.json
+++ b/change/@ni-eslint-config-angular-0fb9c127-1ff4-4c09-8790-86ea0527226c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fv attribute list config",
+  "packageName": "@ni/eslint-config-angular",
+  "email": "1588923+rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config-angular/lib/ok/fv/ignore-attributes.js
+++ b/packages/eslint-config-angular/lib/ok/fv/ignore-attributes.js
@@ -1,0 +1,4 @@
+// Fv angular attributes that SHOULD NOT be localized in production (i.e. enums)
+
+export const fvIgnoreAttributes = [
+];

--- a/packages/eslint-config-angular/lib/template-options.js
+++ b/packages/eslint-config-angular/lib/template-options.js
@@ -10,6 +10,9 @@
 // CSS selector style element[attribute] ignore entries
 // which can be used to scope attribute ignores to specific
 // elements.
+
+import { fvIgnoreAttributes } from './ok/fv/ignore-attributes';
+
 const ignoreAttributeSets = {
     web: [
         'accept',
@@ -110,6 +113,10 @@ const ignoreAttributeSets = {
     spright: [
         // chat
         'message-type'
+    ],
+    ok: [
+        // fv
+        ...fvIgnoreAttributes
     ],
     systemlink: [
         // gainsights telemetry

--- a/packages/eslint-config-angular/lib/template-options.js
+++ b/packages/eslint-config-angular/lib/template-options.js
@@ -11,7 +11,7 @@
 // which can be used to scope attribute ignores to specific
 // elements.
 
-import { fvIgnoreAttributes } from './ok/fv/ignore-attributes';
+import { fvIgnoreAttributes } from './ok/fv/ignore-attributes.js';
 
 const ignoreAttributeSets = {
     web: [


### PR DESCRIPTION
- Added a list of attribute ignores for ok fv components, see https://github.com/ni/nimble/pull/2954
- Update CODEOWNERS to copy the pattern in nimble for fv ownership